### PR TITLE
Add audit-libs-devel to the dev env

### DIFF
--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -6,9 +6,9 @@ FROM centos:7
 
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/fedora-21/Dockerfile
+++ b/contrib/builder/rpm/fedora-21/Dockerfile
@@ -5,9 +5,9 @@
 FROM fedora:21
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -5,9 +5,9 @@
 FROM fedora:22
 
 RUN yum install -y @development-tools fedora-packager
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/generate.sh
+++ b/contrib/builder/rpm/generate.sh
@@ -58,6 +58,7 @@ for version in "${versions[@]}"; do
 
 	# this list is sorted alphabetically; please keep it that way
 	packages=(
+		audit-libs-devel audit-libs-static # for "libaudit.{h,so,a}"
 		btrfs-progs-devel # for "btrfs/ioctl.h" (and "version.h" if possible)
 		device-mapper-devel # for "libdevmapper.h"
 		glibc-static

--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
@@ -7,7 +7,7 @@ FROM opensuse:13.2
 RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
 RUN zypper --non-interactive install audit-libs-devel audit-libs-static libbtrfs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/oraclelinux-6/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-6/Dockerfile
@@ -5,9 +5,9 @@
 FROM oraclelinux:6
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -5,9 +5,9 @@
 FROM oraclelinux:7
 
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libselinux-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
-ENV GO_VERSION 1.4.2
+ENV GO_VERSION 1.4.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/distribution/Centos.json
+++ b/distribution/Centos.json
@@ -2,6 +2,8 @@
     "distribution": "FROM centos",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/Fedora.json
+++ b/distribution/Fedora.json
@@ -2,6 +2,8 @@
     "distribution": "FROM fedora",
     "dependencies":[
       "  RUN dnf -y update && dnf install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",

--- a/distribution/RHEL.json
+++ b/distribution/RHEL.json
@@ -2,6 +2,8 @@
     "distribution": "FROM rhel",
     "dependencies":[
       "  RUN yum -y update && yum install -y \\",
+      "  audit-libs-devel \\",
+      "  audit-libs-static \\",
       "  binutils \\",
       "  btrfs-progs-devel \\",
       "  btrfs-progs \\",


### PR DESCRIPTION
This patch somehow got lost during the latest rebase. Add it back,
otherwise docker fails to compile.

```
---> Making bundle: dynbinary (in bundles/1.9.0-dev/dynbinary)
Created binary: bundles/1.9.0-dev/dynbinary/dockerinit-1.9.0-dev
Building: bundles/1.9.0-dev/dynbinary/docker-1.9.0-dev
# github.com/docker/docker/pkg/audit
pkg/audit/audit_linux.go:12:23: fatal error: libaudit.h: No such file or directory
 // #include "libaudit.h"
                       ^
compilation terminated.
```