### PR TITLE
[cherry-pick] Makefile: don't allocate pseudo-tty if not interactive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,19 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 DOCKER_IMAGE := docker-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 
-DOCKER_RUN_DOCKER := docker run --rm -it --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
+DOCKER_FLAGS := docker run --rm -i --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT)
 
-DOCKER_RUN_DOCS := docker run --rm -it $(DOCS_MOUNT) -e AWS_S3_BUCKET -e NOCACHE
+# if this session isn't interactive, then we don't want to allocate a
+# TTY, which would fail, but if it is interactive, we do want to attach
+# so that the user can send e.g. ^C through.
+INTERACTIVE := $(shell [ -t 0 ] && echo 1 || echo 0)
+ifeq ($(INTERACTIVE), 1)
+	DOCKER_FLAGS += -t
+endif
 
 DOCKER_FILE := $(shell go run ./distribution/gen_dockerfile.go)
 
-# for some docs workarounds (see below in "docs-build" target)
-GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
+DOCKER_RUN_DOCKER := $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
 
 default: binary
 


### PR DESCRIPTION
This is a cherry-pick of upstream PR #17242.

---

In cases where we are running non-interactively (e.g. on Jenkins), we
shouldn't try to allocate a TTY, which would fail. This patch makes the
flag `-t` be dependent on whether the shell session is interactive or
not.

When it is interactive, it's important to have `-t` so that the user can
pass signals through to the process.

We also remove the DOCKER_RUN_DOCS and the GITCOMMIT variables, which
are no longer in use in this Makefile (seems like the related targets
that used it were migrated to docs/Makefile).

Signed-off-by: Jonathan Lebon <jlebon@redhat.com>