### PR TITLE
import/export our patches

### DIFF
--- a/patch/0001-Explain-Patches.patch
+++ b/patch/0001-Explain-Patches.patch
@@ -1,0 +1,157 @@
+From 599036b55653020f5d72268e720c47dc8dbb62da Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Fri, 16 Oct 2015 12:16:50 -0400
+Subject: [PATCH 01/13] Explain Patches
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ README.md | 136 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 136 insertions(+)
+
+diff --git a/README.md b/README.md
+index 4764303..010483c 100644
+--- a/README.md
++++ b/README.md
+@@ -1,3 +1,139 @@
++## Red Hat Patches
++Red Hat is carrying a series of experimental patches that we feel are required
++for our customers or for our support engineering.
++
++#### Warning-message-for-lvm-devmapper-running-on-top-of-.patch
++
++Red Hat File System support engineers are very concerned about a customer
++running docker storage using device mapper on top of loopback devices in
++production.  We ship docker by default with this setup so that you can easily
++run/build/test containers without having to setup dedicated storage for the
++containers, but when you want to run the containers in production, you need
++to setup the storage.  Docker upstream accepted a patch to log this information
++but did not like the output showing up in the `docker run` client.
++
++#### Return-rpm-version-of-packages-in-docker-version.patch
++
++Red Hat Support wants to know the version of the rpm package that docker
++is running.  This patch allows the distribution to show the rpm version
++of the client and server using the `docker info` command.  Docker upstream
++was not interested in this patch. This patch only affects the `docker info`
++command.
++
++https://github.com/docker/docker/pull/14591
++
++#### Change-the-default-mount-mode-of-containers-from-Pri.patch
++
++Red Hat wants the default mount propagation to be Slave instead of Private.
++This allows volume (bind) mounts, to be altered on the host and the new
++mounts show up inside of the container.  We use this functionality for several
++use cases.  Kubernetes uses it to be able to add mount points on the host.  We
++want to allow Automount to work from the host inside of the container.  We also
++want to eventually allow mounting from inside of a container to alter the mount
++points on the host.  We have gotten several patches accepted into the docker
++to support these use cases, and we hope to have all use cases supported by
++docker-1.10.
++
++https://github.com/docker/libcontainer/pull/623
++
++Two related pull requests:
++
++https://github.com/docker/docker/pull/16773
++
++https://github.com/docker/docker/pull/17034
++
++#### rebase-distribution-specific-build.patch
++
++Current docker tests run totally on Ubuntu.  We want to be able to make sure
++all tests run on platforms and containers we support.  This patch allows us
++to run distribution specific tests. This means that `make test` on RHEL7 will
++use rhel7 based images for the test, and `make test` on Fedora will use
++fedora based images for the test.  Docker was not crazy about the substitutions
++done in this patch, and the changes never show up in the docker client/daemon
++that we ship.
++
++https://github.com/docker/docker/pull/15364
++
++#### Add-RHEL-super-secrets-patch.patch
++
++This patch allows us to provide subscription management information from the
++host into containers for both `docker run` and `docker build`.  In order to get
++access to RHEL7 and RHEL6 content inside of a container via yum you need to
++use a subscription.  This patch allows the subscriptions to work inside of the
++container.  Docker thought this was too RHEL specific so told us to carry a
++patch.
++
++https://github.com/docker/docker/pull/6075
++
++#### Add-add-registry-and-block-registry-options-to-docke.patch
++
++Customers have been asking for us to provide a mechanism to allow additional
++registries to be specified in addition to docker.io.  We also want to have
++Red Hat Content available from our Registry by default. This patch allows
++users to customize the default registries available.  We believe this closely
++aligns with the way yum and apt currently work.  This patch also allows
++customers to block images from registries.  Some customers do not want software
++to be accidentally pulled and run on a machine.  Some customers also have no
++access to the internet and want to setup private registries to handle their
++content.
++
++https://github.com/docker/docker/pull/11991
++https://github.com/docker/docker/pull/10411
++
++#### Confirm-a-push-to-public-Docker-registry.patch
++
++Red Hat content is not supposed to be shared with other customers. For example
++RHE7 and RHEL6 base images are not supposed to be shared with a public registry.
++Pushing content to the docker registry breaks the subscription agreement with
++Red Hat. The patch helps prevent customers from accidentally pushing,
++`docker push`, RHEL content to docker.io
++
++#### Improved-searching-experience.patch
++
++Red Hat wants to allow users to search multiple registries as described above.
++This patch improves the search experience.
++
++#### Allow-for-remote-repository-inspection.patch
++
++Red Hat wants to be able to search the json content on a registry, specifically
++looking for things like labels. This patch allow `atomic verify` to examine
++layers of an image and then search the registry for newer versions.  For example
++you might be running a jboss application that is based on RHEL7.1 base image,
++`atomic verify` would then search registries for alternate RHEL7 base images.
++If it found a base image of RHEL7.2 it would notify the user.
++
++https://github.com/docker/docker/pull/14258
++
++#### Fixed-docker-s-authentication-issue.patch
++
++Docker client sends configuration file with stored credentials together
++with several requests to Docker daemon. Daemon then takes the first
++authentication information and tries to use it against any registry it
++contacts. This results in authentication errors while trying pull from
++any registry but the one stored first in configuration file. This patch
++checks whether the given credentials belong to desired endpoint before
++creating an new session.  This patch is required to support multiple
++registries.
++
++#### System-logging-for-docker-daemon-API-calls.patch
++Red Hat wants to log all access to the docker daemon.  This patch records all
++access to the docker daemon in syslog/journald.  Currently docker logs access
++in its event logs but these logs are not stored permanently and do not record
++critical information like loginuid to record which user created/started/stopped
++... containers.  We will continue to work with Docker to get this patch
++merged. Docker indicates that they want to wait until the authentication patches
++get merged.
++
++https://github.com/docker/docker/pull/14446
++
++#### Audit-logging-support-for-daemon-API-calls.patch
++
++This is a follow on patch to the previous syslog patch, to record all auditable
++events to the audit log.  We want to get `docker daemon` to some level of common
++criteria.  In order to do this administrator activity must be audited.
++
++https://github.com/rhatdan/docker/pull/109
++
+ Docker: the container engine [![Release](https://img.shields.io/github/release/docker/docker.svg)](https://github.com/docker/docker/releases/latest)
+ ============================
+ 
+-- 
+2.5.0
+

--- a/patch/0002-Distribution-specific-build.patch
+++ b/patch/0002-Distribution-specific-build.patch
@@ -1,0 +1,363 @@
+From b348ca9f5e1ae3f3a70e54cfdf93855886387315 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Mon, 7 Dec 2015 12:03:09 -0500
+Subject: [PATCH 02/13] Distribution-specific build
+
+Signed-off-by: Sally O'Malley <somalley@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ Dockerfile                |  26 +++++-----
+ Makefile                  |   1 +
+ distros/Centos.json       |  37 ++++++++++++++
+ distros/Fedora.json       |  38 ++++++++++++++
+ distros/RHEL.json         |  37 ++++++++++++++
+ distros/gen_dockerfile.go | 123 ++++++++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 250 insertions(+), 12 deletions(-)
+ create mode 100644 distros/Centos.json
+ create mode 100644 distros/Fedora.json
+ create mode 100644 distros/RHEL.json
+ create mode 100644 distros/gen_dockerfile.go
+
+diff --git a/Dockerfile b/Dockerfile
+index 93016c9..1a503a7 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -23,6 +23,7 @@
+ # the case. Therefore, you don't have to disable it anymore.
+ #
+ 
++# Cut for distribution specific
+ FROM ubuntu:14.04
+ MAINTAINER Tianon Gravi <admwiggin@gmail.com> (@tianon)
+ 
+@@ -68,8 +69,17 @@ RUN apt-get update && apt-get install -y \
+ 	libzfs-dev \
+ 	tar \
+ 	--no-install-recommends \
+-	&& ln -snf /usr/bin/clang-3.8 /usr/local/bin/clang \
+-	&& ln -snf /usr/bin/clang++-3.8 /usr/local/bin/clang++
++# End dependencies cut
++	automake \
++	git \
++	jq \
++	iptables \
++	libtool \
++	mercurial \
++	parallel \
++	python-devel \
++	python-mock \
++	python-pip
+ 
+ # Get lvm2 source for compiling statically
+ RUN git clone -b v2_02_103 https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2
+@@ -91,7 +101,6 @@ ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
+ # Compile Go for cross compilation
+ ENV DOCKER_CROSSPLATFORMS \
+ 	linux/386 linux/arm \
+-	darwin/amd64 darwin/386 \
+ 	freebsd/amd64 freebsd/386 freebsd/arm \
+ 	windows/amd64 windows/386
+ 
+@@ -116,15 +125,6 @@ RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint
+ 	&& (cd /go/src/github.com/golang/lint && git checkout -q $GO_LINT_COMMIT) \
+ 	&& go install -v github.com/golang/lint/golint
+ 
+-# Configure the container for OSX cross compilation
+-ENV OSX_SDK MacOSX10.11.sdk
+-RUN set -x \
+-	&& export OSXCROSS_PATH="/osxcross" \
+-	&& git clone --depth 1 https://github.com/tpoechtrager/osxcross.git $OSXCROSS_PATH \
+-	&& curl -sSL https://s3.dockerproject.org/darwin/${OSX_SDK}.tar.xz -o "${OSXCROSS_PATH}/tarballs/${OSX_SDK}.tar.xz" \
+-	&& UNATTENDED=yes OSX_VERSION_MIN=10.6 ${OSXCROSS_PATH}/build.sh
+-ENV PATH /osxcross/target/bin:$PATH
+-
+ # install seccomp
+ # this can be changed to the ubuntu package libseccomp-dev if dockerinit is removed,
+ # we need libseccomp.a (which the package does not provide) for dockerinit
+@@ -185,7 +185,9 @@ RUN useradd --create-home --gid docker unprivilegeduser
+ 
+ VOLUME /var/lib/docker
+ WORKDIR /go/src/github.com/docker/docker
++#  Cut for buildtags distribution specific
+ ENV DOCKER_BUILDTAGS apparmor seccomp selinux
++# End buildtags cut
+ 
+ # Let us use a .bashrc file
+ RUN ln -sfv $PWD/.bashrc ~/.bashrc
+diff --git a/Makefile b/Makefile
+index 58f4dff..942e9a2 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,6 +58,7 @@ ifeq ($(INTERACTIVE), 1)
+ endif
+ 
+ DOCKER_RUN_DOCKER := $(DOCKER_FLAGS) "$(DOCKER_IMAGE)"
++DOCKER_FILE := $(shell go run ./distros/gen_dockerfile.go)
+ 
+ default: binary
+ 
+diff --git a/distros/Centos.json b/distros/Centos.json
+new file mode 100644
+index 0000000..8ff787c
+--- /dev/null
++++ b/distros/Centos.json
+@@ -0,0 +1,37 @@
++{
++    "distribution": "FROM centos",
++    "dependencies":[
++      "  RUN yum -y update && yum install -y \\",
++      "  audit-libs-devel \\",
++      "  binutils \\",
++      "  btrfs-progs-devel \\",
++      "  btrfs-progs \\",
++      "  bzip2 \\",
++      "  clang \\",
++      "  gcc \\",
++      "  gcc-c++ \\",
++      "  glibc-static \\",
++      "  glibc-devel \\",
++      "  glibc-headers \\",
++      "  golang-googlecode-sqlite-devel \\",
++      "  kernel-devel \\",
++      "  libcap-devel \\",
++      "  libvirt-client \\",
++      "  libguestfs-tools \\",
++      "  make \\",
++      "  mingw64-gcc \\",
++      "  php-devel \\",
++      "  python-websocket-client \\",
++      "  python-requests \\",
++      "  redhat-rpm-config \\",
++      "  rpm-devel \\",
++      "  ruby \\",
++      "  ruby-devel \\",
++      "  tar \\" ],
++    "buildtags": "ENV DOCKER_BUILDTAGS seccomp selinux",
++    "markers": [
++      "Cut for distribution specific",
++      "End dependencies cut",
++      "Cut for buildtags distribution",
++      "End buildtags cut" ]
++}
+diff --git a/distros/Fedora.json b/distros/Fedora.json
+new file mode 100644
+index 0000000..757d371
+--- /dev/null
++++ b/distros/Fedora.json
+@@ -0,0 +1,38 @@
++{
++    "distribution": "FROM fedora",
++    "dependencies":[
++      "  RUN dnf -y update && dnf install -y \\",
++      "  audit-libs-devel \\",
++      "  binutils \\",
++      "  btrfs-progs-devel \\",
++      "  btrfs-progs \\",
++      "  bzip2 \\",
++      "  clang \\",
++      "  gcc \\",
++      "  gcc-c++ \\",
++      "  glibc-static \\",
++      "  glibc-devel \\",
++      "  glibc-headers \\",
++      "  golang-googlecode-sqlite-devel \\",
++      "  kernel-devel \\",
++      "  libcap-devel \\",
++      "  libvirt-client \\",
++      "  libguestfs-tools \\",
++      "  make \\",
++      "  mingw64-gcc \\",
++      "  net-tools \\",
++      "  php-devel \\",
++      "  python-websocket-client \\",
++      "  python-requests \\",
++      "  redhat-rpm-config \\",
++      "  rpm-devel \\",
++      "  ruby \\",
++      "  ruby-devel \\",
++      "  tar \\" ],
++    "buildtags": "ENV DOCKER_BUILDTAGS seccomp selinux",
++    "markers": [
++      "Cut for distribution specific",
++      "End dependencies cut",
++      "Cut for buildtags distribution",
++      "End buildtags cut" ]
++}
+diff --git a/distros/RHEL.json b/distros/RHEL.json
+new file mode 100644
+index 0000000..332f7ee
+--- /dev/null
++++ b/distros/RHEL.json
+@@ -0,0 +1,37 @@
++{
++    "distribution": "FROM rhel",
++    "dependencies":[
++      "  RUN yum -y update && yum install -y \\",
++      "  audit-libs-devel \\",
++      "  binutils \\",
++      "  btrfs-progs-devel \\",
++      "  btrfs-progs \\",
++      "  bzip2 \\",
++      "  clang \\",
++      "  gcc \\",
++      "  gcc-c++ \\",
++      "  glibc-static \\",
++      "  glibc-devel \\",
++      "  glibc-headers \\",
++      "  golang-googlecode-sqlite-devel \\",
++      "  kernel-devel \\",
++      "  libcap-devel \\",
++      "  libvirt-client \\",
++      "  libguestfs-tools \\",
++      "  make \\",
++      "  mingw64-gcc \\",
++      "  php-devel \\",
++      "  python-websocket-client \\",
++      "  python-requests \\",
++      "  redhat-rpm-config \\",
++      "  rpm-devel \\",
++      "  ruby \\",
++      "  ruby-devel \\",
++      "  tar \\" ],
++    "buildtags": "ENV DOCKER_BUILDTAGS seccomp selinux",
++    "markers": [
++      "Cut for distribution specific",
++      "End dependencies cut",
++      "Cut for buildtags distribution",
++      "End buildtags cut" ]
++}
+diff --git a/distros/gen_dockerfile.go b/distros/gen_dockerfile.go
+new file mode 100644
+index 0000000..9b193d3
+--- /dev/null
++++ b/distros/gen_dockerfile.go
+@@ -0,0 +1,123 @@
++package main
++
++import (
++	"bufio"
++	"encoding/json"
++	"fmt"
++	"io/ioutil"
++	"log"
++	"os"
++	"strings"
++)
++
++// DfileConfig holds info for distribution-specific Dockerfile
++type DfileConfig struct {
++	Distribution string   `json:"distribution"`
++	Dependencies []string `json:"dependencies"`
++	Buildtags    string   `json:"buildtags"`
++	Markers      []string `json:"markers"`
++}
++
++func check(err error) {
++	if err != nil {
++		panic(err)
++	}
++}
++func genOS() (string, error) {
++	file, err := ioutil.ReadFile("/etc/redhat-release")
++	if err != nil {
++		return "Dockerfile", nil
++	}
++	line := strings.Split(string(file), " ")
++	osStr := line[0]
++	switch osStr {
++	case "Fedora":
++		return "Fedora", nil
++	case "CentOS":
++		return "Centos", nil
++	case "Red":
++		return "RHEL", nil
++	default:
++		return "", nil
++	}
++}
++
++func genDockerfileName(osName string) (string, error) {
++	return "distros/Dockerfile" + osName, nil
++}
++
++func patchLines(patched string, original string, osName string) error {
++	patchedFile, err := os.Create(patched)
++	check(err)
++	w := bufio.NewWriter(patchedFile)
++	defer w.Flush()
++	dfConfig := new(DfileConfig)
++	patchJSON := fmt.Sprintf("distros/%s.json", osName)
++	patchJSONFile, err := os.Open(patchJSON)
++	check(err)
++	defer patchJSONFile.Close()
++	jsonParser := json.NewDecoder(patchJSONFile)
++	check(err)
++	err = jsonParser.Decode(&dfConfig)
++	check(err)
++	origDf, err := os.Open(original)
++	check(err)
++	defer origDf.Close()
++	scanner := bufio.NewScanner(origDf)
++	scanner.Split(bufio.ScanLines)
++	i := 0 // will increment to avoid multiple writes of same lines
++	for scanner.Scan() {
++		switch i {
++		case 0:
++			if !strings.Contains(scanner.Text(), dfConfig.Markers[0]) {
++				fmt.Fprintln(w, scanner.Text())
++			} else {
++				fmt.Fprintln(w, scanner.Text())
++				fmt.Fprintln(w, dfConfig.Distribution)
++				for _, dep := range dfConfig.Dependencies {
++					fmt.Fprintln(w, dep)
++				}
++				i++
++			}
++		case 1:
++			if strings.Contains(scanner.Text(), dfConfig.Markers[1]) {
++				fmt.Fprintln(w, scanner.Text())
++				i++
++			}
++		case 2:
++			if !strings.Contains(scanner.Text(), dfConfig.Markers[2]) {
++				fmt.Fprintln(w, scanner.Text())
++			} else {
++				fmt.Fprintln(w, scanner.Text())
++				fmt.Fprintln(w, dfConfig.Buildtags)
++				i++
++			}
++		case 3:
++			if strings.Contains(scanner.Text(), dfConfig.Markers[3]) {
++				fmt.Fprintln(w, scanner.Text())
++				i++
++			}
++		default:
++			fmt.Fprintln(w, scanner.Text())
++		}
++	}
++	return nil
++}
++
++func main() {
++	osName, err := genOS()
++	if err != nil {
++		log.Fatal(err)
++	}
++	patchedDockerfile, err := genDockerfileName(osName)
++	if err != nil {
++		log.Fatal(err)
++	}
++	if patchedDockerfile != "Dockerfile" {
++		err = patchLines(patchedDockerfile, "Dockerfile", osName)
++		if err != nil {
++			log.Fatal(err)
++		}
++	}
++	fmt.Println(patchedDockerfile)
++}
+-- 
+2.5.0
+

--- a/patch/0003-Return-rpm-version-of-packages-in-docker-version.patch
+++ b/patch/0003-Return-rpm-version-of-packages-in-docker-version.patch
@@ -1,0 +1,228 @@
+From 52d0af428e7706fbd2a7511d2a95b944572dc268 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Mon, 14 Dec 2015 16:33:39 -0500
+Subject: [PATCH 03/13] Return rpm version of packages in docker version
+
+Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
+
+Dan Walsh <dwalsh@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/client/version.go                      | 33 +++++++++++++++++-------------
+ api/types/types.go                         |  2 ++
+ daemon/info.go                             |  5 +++++
+ integration-cli/docker_cli_version_test.go | 26 +++++++++++------------
+ pkg/rpm/rpm.go                             | 20 ++++++++++++++++++
+ 5 files changed, 59 insertions(+), 27 deletions(-)
+ create mode 100644 pkg/rpm/rpm.go
+
+diff --git a/api/client/version.go b/api/client/version.go
+index 61125ce..41fc26f 100644
+--- a/api/client/version.go
++++ b/api/client/version.go
+@@ -10,26 +10,29 @@ import (
+ 	Cli "github.com/docker/docker/cli"
+ 	"github.com/docker/docker/dockerversion"
+ 	flag "github.com/docker/docker/pkg/mflag"
++	"github.com/docker/docker/pkg/rpm"
+ 	"github.com/docker/docker/utils"
+ )
+ 
+ var versionTemplate = `Client:
+- Version:      {{.Client.Version}}
+- API version:  {{.Client.APIVersion}}
+- Go version:   {{.Client.GoVersion}}
+- Git commit:   {{.Client.GitCommit}}
+- Built:        {{.Client.BuildTime}}
+- OS/Arch:      {{.Client.Os}}/{{.Client.Arch}}{{if .Client.Experimental}}
+- Experimental: {{.Client.Experimental}}{{end}}{{if .ServerOK}}
++ Version:         {{.Client.Version}}
++ API version:     {{.Client.APIVersion}}
++ Package version: {{.Client.PkgVersion}}
++ Go version:      {{.Client.GoVersion}}
++ Git commit:      {{.Client.GitCommit}}
++ Built:           {{.Client.BuildTime}}
++ OS/Arch:         {{.Client.Os}}/{{.Client.Arch}}{{if .Client.Experimental}}
++ Experimental:    {{.Client.Experimental}}{{end}}{{if .ServerOK}}
+ 
+ Server:
+- Version:      {{.Server.Version}}
+- API version:  {{.Server.APIVersion}}
+- Go version:   {{.Server.GoVersion}}
+- Git commit:   {{.Server.GitCommit}}
+- Built:        {{.Server.BuildTime}}
+- OS/Arch:      {{.Server.Os}}/{{.Server.Arch}}{{if .Server.Experimental}}
+- Experimental: {{.Server.Experimental}}{{end}}{{end}}`
++ Version:         {{.Server.Version}}
++ API version:     {{.Server.APIVersion}}
++ Package version: {{.Server.PkgVersion}}
++ Go version:      {{.Server.GoVersion}}
++ Git commit:      {{.Server.GitCommit}}
++ Built:           {{.Server.BuildTime}}
++ OS/Arch:         {{.Server.Os}}/{{.Server.Arch}}{{if .Server.Experimental}}
++ Experimental:    {{.Server.Experimental}}{{end}}{{end}}`
+ 
+ // CmdVersion shows Docker version information.
+ //
+@@ -53,6 +56,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
+ 		return Cli.StatusError{StatusCode: 64,
+ 			Status: "Template parsing error: " + err.Error()}
+ 	}
++	packageVersion, _ := rpm.Version("/usr/bin/docker")
+ 
+ 	vd := types.VersionResponse{
+ 		Client: &types.Version{
+@@ -64,6 +68,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
+ 			Os:           runtime.GOOS,
+ 			Arch:         runtime.GOARCH,
+ 			Experimental: utils.ExperimentalBuild(),
++			PkgVersion:   packageVersion,
+ 		},
+ 	}
+ 
+diff --git a/api/types/types.go b/api/types/types.go
+index c85d41f..3982051 100644
+--- a/api/types/types.go
++++ b/api/types/types.go
+@@ -178,6 +178,7 @@ type Version struct {
+ 	KernelVersion string `json:",omitempty"`
+ 	Experimental  bool   `json:",omitempty"`
+ 	BuildTime     string `json:",omitempty"`
++	PkgVersion    string `json:",omitempty"`
+ }
+ 
+ // Info contains response of Remote API:
+@@ -207,6 +208,7 @@ type Info struct {
+ 	LoggingDriver      string
+ 	NEventsListener    int
+ 	KernelVersion      string
++	PkgVersion         string
+ 	OperatingSystem    string
+ 	OSType             string
+ 	Architecture       string
+diff --git a/daemon/info.go b/daemon/info.go
+index 76427cc..804bbeb 100644
+--- a/daemon/info.go
++++ b/daemon/info.go
+@@ -13,6 +13,7 @@ import (
+ 	"github.com/docker/docker/pkg/parsers/kernel"
+ 	"github.com/docker/docker/pkg/parsers/operatingsystem"
+ 	"github.com/docker/docker/pkg/platform"
++	"github.com/docker/docker/pkg/rpm"
+ 	"github.com/docker/docker/pkg/sysinfo"
+ 	"github.com/docker/docker/pkg/system"
+ 	"github.com/docker/docker/registry"
+@@ -53,6 +54,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 	// by hand given VERSION)
+ 	initPath := utils.DockerInitPath("")
+ 	sysInfo := sysinfo.New(true)
++	packageVersion, _ := rpm.Version("/usr/bin/docker")
+ 
+ 	v := &types.Info{
+ 		ID:                 daemon.ID,
+@@ -90,6 +92,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 		HTTPProxy:          getProxyEnv("http_proxy"),
+ 		HTTPSProxy:         getProxyEnv("https_proxy"),
+ 		NoProxy:            getProxyEnv("no_proxy"),
++		PkgVersion:         packageVersion,
+ 	}
+ 
+ 	// TODO Windows. Refactor this more once sysinfo is refactored into
+@@ -115,6 +118,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 
+ // SystemVersion returns version information about the daemon.
+ func (daemon *Daemon) SystemVersion() types.Version {
++	pkgVersion, _ := rpm.Version("/usr/bin/docker")
+ 	v := types.Version{
+ 		Version:      dockerversion.Version,
+ 		GitCommit:    dockerversion.GitCommit,
+@@ -123,6 +127,7 @@ func (daemon *Daemon) SystemVersion() types.Version {
+ 		Arch:         runtime.GOARCH,
+ 		BuildTime:    dockerversion.BuildTime,
+ 		Experimental: utils.ExperimentalBuild(),
++		PkgVersion:   pkgVersion,
+ 	}
+ 
+ 	if kernelVersion, err := kernel.GetKernelVersion(); err == nil {
+diff --git a/integration-cli/docker_cli_version_test.go b/integration-cli/docker_cli_version_test.go
+index 7672beb..b439e6e 100644
+--- a/integration-cli/docker_cli_version_test.go
++++ b/integration-cli/docker_cli_version_test.go
+@@ -11,14 +11,15 @@ import (
+ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
+ 	out, _ := dockerCmd(c, "version")
+ 	stringsToCheck := map[string]int{
+-		"Client:":       1,
+-		"Server:":       1,
+-		" Version:":     2,
+-		" API version:": 2,
+-		" Go version:":  2,
+-		" Git commit:":  2,
+-		" OS/Arch:":     2,
+-		" Built:":       2,
++		"Client:":           1,
++		"Server:":           1,
++		" Version:":         2,
++		" API version:":     2,
++		" Package version:": 2,
++		" Go version:":      2,
++		" Git commit:":      2,
++		" OS/Arch:":         2,
++		" Built:":           2,
+ 	}
+ 
+ 	for k, v := range stringsToCheck {
+@@ -40,19 +41,18 @@ func (s *DockerSuite) TestVersionPlatform_l(c *check.C) {
+ 
+ func testVersionPlatform(c *check.C, platform string) {
+ 	out, _ := dockerCmd(c, "version")
+-	expected := "OS/Arch:      " + platform
+ 
+ 	split := strings.Split(out, "\n")
+-	c.Assert(len(split) >= 14, checker.Equals, true, check.Commentf("got %d lines from version", len(split)))
++	c.Assert(len(split) >= 16, checker.Equals, true, check.Commentf("got %d lines from version", len(split)))
+ 
+ 	// Verify the second 'OS/Arch' matches the platform. Experimental has
+ 	// more lines of output than 'regular'
+ 	bFound := false
+-	for i := 14; i < len(split); i++ {
+-		if strings.Contains(split[i], expected) {
++	for i := 16; i < len(split); i++ {
++		if strings.Contains(split[i], "OS/Arch:") && strings.Contains(split[i], platform) {
+ 			bFound = true
+ 			break
+ 		}
+ 	}
+-	c.Assert(bFound, checker.Equals, true, check.Commentf("Could not find server '%s' in '%s'", expected, out))
++	c.Assert(bFound, checker.Equals, true, check.Commentf("Could not find server 'OS/Arch:' or '%s' in '%s'", platform, out))
+ }
+diff --git a/pkg/rpm/rpm.go b/pkg/rpm/rpm.go
+new file mode 100644
+index 0000000..494fc94
+--- /dev/null
++++ b/pkg/rpm/rpm.go
+@@ -0,0 +1,20 @@
++package rpm
++
++import (
++	"os/exec"
++	"strings"
++)
++
++// Version returns package version for the specified package or executable path
++func Version(name string) (string, error) {
++	var (
++		err    error
++		out    []byte
++		option = "-q"
++	)
++	if name[0] == '/' {
++		option = "-qf"
++	}
++	out, err = exec.Command("/usr/bin/rpm", option, name).Output()
++	return strings.Trim(string(out), "\n"), err
++}
+-- 
+2.5.0
+

--- a/patch/0004-Change-the-default-mount-mode-of-containers-from-Pri.patch
+++ b/patch/0004-Change-the-default-mount-mode-of-containers-from-Pri.patch
@@ -1,0 +1,31 @@
+From 988936aaea5d6a5bd475c6d49559384c71dc444d Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Tue, 15 Dec 2015 13:43:12 -0500
+Subject: [PATCH 04/13] Change the default mount mode of containers from
+ Private to slave
+
+Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
+
+Dan Walsh <dwalsh@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ daemon/execdriver/driver_unix.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/daemon/execdriver/driver_unix.go b/daemon/execdriver/driver_unix.go
+index 1a72fd1..81c9f77 100644
+--- a/daemon/execdriver/driver_unix.go
++++ b/daemon/execdriver/driver_unix.go
+@@ -143,7 +143,7 @@ func InitContainer(c *Command) *configs.Config {
+ 	container.Readonlyfs = c.ReadonlyRootfs
+ 	// This can be overridden later by driver during mount setup based
+ 	// on volume options
+-	SetRootPropagation(container, mount.RPRIVATE)
++	SetRootPropagation(container, mount.RSLAVE)
+ 
+ 	// check to see if we are running in ramdisk to disable pivot root
+ 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
+-- 
+2.5.0
+

--- a/patch/0005-Add-RHEL-super-secrets-patch.patch
+++ b/patch/0005-Add-RHEL-super-secrets-patch.patch
@@ -1,0 +1,237 @@
+From 172141887d52b858dcb70bda9b4ad13b10478a62 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Mon, 7 Dec 2015 08:39:15 -0500
+Subject: [PATCH 05/13] Add RHEL super secrets patch
+
+Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
+
+Dan Walsh <dwalsh@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ daemon/container_operations_unix.go     | 42 ++++++++++++++++
+ daemon/container_operations_windows.go  |  7 +++
+ daemon/secrets.go                       | 85 +++++++++++++++++++++++++++++++++
+ daemon/start.go                         |  6 +++
+ daemon/volumes_unix.go                  | 14 ++++++
+ integration-cli/docker_cli_diff_test.go |  2 +
+ 6 files changed, 156 insertions(+)
+ create mode 100644 daemon/secrets.go
+
+diff --git a/daemon/container_operations_unix.go b/daemon/container_operations_unix.go
+index c965cbb..f455ff8 100644
+--- a/daemon/container_operations_unix.go
++++ b/daemon/container_operations_unix.go
+@@ -850,6 +850,48 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
+ 	}
+ }
+ 
++func (daemon *Daemon) secretsPath(container *container.Container) (string, error) {
++	return container.GetRootResourcePath("secrets")
++}
++func (daemon *Daemon) setupSecretFiles(container *container.Container) error {
++	secretsPath, err := daemon.secretsPath(container)
++	if err != nil {
++		return err
++	}
++
++	if err := os.MkdirAll(secretsPath, 0700); err != nil {
++		return err
++	}
++
++	if err := syscall.Mount("tmpfs", secretsPath, "tmpfs", uintptr(syscall.MS_NOEXEC|syscall.MS_NOSUID|syscall.MS_NODEV), label.FormatMountLabel("", container.GetMountLabel())); err != nil {
++		return fmt.Errorf("mounting secret tmpfs: %s", err)
++	}
++
++	data, err := getHostSecretData()
++	if err != nil {
++		return err
++	}
++	for _, s := range data {
++		s.SaveTo(secretsPath)
++	}
++
++	return nil
++}
++
++func (daemon *Daemon) cleanupSecrets(container *container.Container) {
++	// Now the container is running, unmount the secrets on the host
++	secretsPath, err := daemon.secretsPath(container)
++	if err != nil {
++		logrus.Errorf("%v: Secrets Path does not exist: %v", container.ID, err)
++		return
++	}
++
++	if err := syscall.Unmount(secretsPath, 0); err != nil {
++		logrus.Errorf("%v: Failed to umount %s filesystem: %v", container.ID, secretsPath, err)
++		return
++	}
++}
++
+ func (daemon *Daemon) setupIpcDirs(c *container.Container) error {
+ 	rootUID, rootGID := daemon.GetRemappedUIDGID()
+ 	if !c.HasMountFor("/dev/shm") {
+diff --git a/daemon/container_operations_windows.go b/daemon/container_operations_windows.go
+index 37524d3..583e748 100644
+--- a/daemon/container_operations_windows.go
++++ b/daemon/container_operations_windows.go
+@@ -170,3 +170,10 @@ func detachMounted(path string) error {
+ func killProcessDirectly(container *container.Container) error {
+ 	return nil
+ }
++
++func (daemon *Daemon) cleanupSecrets(container *container.Container) {
++	return
++}
++func (daemon *Daemon) setupSecretFiles(container *container.Container) error {
++	return nil
++}
+diff --git a/daemon/secrets.go b/daemon/secrets.go
+new file mode 100644
+index 0000000..dabc290
+--- /dev/null
++++ b/daemon/secrets.go
+@@ -0,0 +1,85 @@
++package daemon
++
++import (
++	"io/ioutil"
++	"os"
++	"path/filepath"
++)
++
++// Secret info
++type Secret struct {
++	Name      string
++	IsDir     bool
++	HostBased bool
++}
++
++// SecretData info
++type SecretData struct {
++	Name string
++	Data []byte
++}
++
++// SaveTo saves secret data to given directory
++func (s SecretData) SaveTo(dir string) error {
++	path := filepath.Join(dir, s.Name)
++	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !os.IsExist(err) {
++		return err
++	}
++	return ioutil.WriteFile(path, s.Data, 0755)
++}
++
++func readAll(root, prefix string) ([]SecretData, error) {
++	path := filepath.Join(root, prefix)
++
++	data := []SecretData{}
++
++	files, err := ioutil.ReadDir(path)
++	if err != nil {
++		if os.IsNotExist(err) {
++			return data, nil
++		}
++
++		return nil, err
++	}
++
++	for _, f := range files {
++		fileData, err := readFile(root, filepath.Join(prefix, f.Name()))
++		if err != nil {
++			// If the file did not exist, might be a dangling symlink
++			// Ignore the error
++			if os.IsNotExist(err) {
++				continue
++			}
++			return nil, err
++		}
++		data = append(data, fileData...)
++	}
++
++	return data, nil
++}
++
++func readFile(root, name string) ([]SecretData, error) {
++	path := filepath.Join(root, name)
++
++	s, err := os.Stat(path)
++	if err != nil {
++		return nil, err
++	}
++
++	if s.IsDir() {
++		dirData, err := readAll(root, name)
++		if err != nil {
++			return nil, err
++		}
++		return dirData, nil
++	}
++	bytes, err := ioutil.ReadFile(path)
++	if err != nil {
++		return nil, err
++	}
++	return []SecretData{{Name: name, Data: bytes}}, nil
++}
++
++func getHostSecretData() ([]SecretData, error) {
++	return readAll("/usr/share/rhel/secrets", "")
++}
+diff --git a/daemon/start.go b/daemon/start.go
+index 44ad1d1..90b745e 100644
+--- a/daemon/start.go
++++ b/daemon/start.go
+@@ -112,6 +112,12 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
+ 		return err
+ 	}
+ 
++	defer daemon.cleanupSecrets(container)
++
++	if err := daemon.setupSecretFiles(container); err != nil {
++		return err
++	}
++
+ 	if !container.HostConfig.IpcMode.IsContainer() && !container.HostConfig.IpcMode.IsHost() {
+ 		if err := daemon.setupIpcDirs(container); err != nil {
+ 			return err
+diff --git a/daemon/volumes_unix.go b/daemon/volumes_unix.go
+index f0d9f2d..4e00a7c 100644
+--- a/daemon/volumes_unix.go
++++ b/daemon/volumes_unix.go
+@@ -18,6 +18,20 @@ import (
+ // /etc/resolv.conf, and if it is not, appends it to the array of mounts.
+ func (daemon *Daemon) setupMounts(container *container.Container) ([]execdriver.Mount, error) {
+ 	var mounts []execdriver.Mount
++
++	secretsPath, err := daemon.secretsPath(container)
++	if err != nil {
++		return nil, err
++	}
++
++	if _, err := os.Stat(secretsPath); !os.IsNotExist(err) {
++		mounts = append(mounts, execdriver.Mount{
++			Source:      secretsPath,
++			Destination: "/run/secrets",
++			Writable:    true,
++		})
++	}
++
+ 	for _, m := range container.MountPoints {
+ 		path, err := m.Setup()
+ 		if err != nil {
+diff --git a/integration-cli/docker_cli_diff_test.go b/integration-cli/docker_cli_diff_test.go
+index 4f29d36..e8e56c4 100644
+--- a/integration-cli/docker_cli_diff_test.go
++++ b/integration-cli/docker_cli_diff_test.go
+@@ -72,6 +72,8 @@ func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
+ 		"A /dev/tty":     true,
+ 		"A /dev/urandom": true,
+ 		"A /dev/zero":    true,
++		"A /run":         true, // secrets patch
++		"A /run/secrets": true, // secrets patch
+ 	}
+ 
+ 	for _, line := range strings.Split(out, "\n") {
+-- 
+2.5.0
+

--- a/patch/0006-Fixed-docker-s-authentication-issue.patch
+++ b/patch/0006-Fixed-docker-s-authentication-issue.patch
@@ -1,0 +1,68 @@
+From 71d29043d8e87fd70d270797e4044073e3fd0e9e Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Mon, 14 Dec 2015 17:14:49 -0500
+Subject: [PATCH 06/13] Fixed docker's authentication issue
+
+Docker client sends configuration file with stored credentials together
+with several requests to Docker daemon. Daemon then takes the first
+authentication information and tries to use it against any registry it
+contacts. This results in authentication errors while trying pull from
+any registry but the one stored first in configuration file. This patch
+checks, whether the given credentials belong to desired endpoint before
+creating an new session.
+
+This is just a workaround. Robust solution would be to iterate over all
+available authentication data and choose the right ones for registry
+currently processed. And client would have to pass all possibly needed
+credentials to docker daemon with any request (it does so only in rare
+cases like docker build).
+
+Signed-off-by: Michal Minar <miminar@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ registry/session.go | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/registry/session.go b/registry/session.go
+index d09babd..102263b 100644
+--- a/registry/session.go
++++ b/registry/session.go
+@@ -15,6 +15,7 @@ import (
+ 	"net/http"
+ 	"net/http/cookiejar"
+ 	"net/url"
++	"regexp"
+ 	"strconv"
+ 	"strings"
+ 
+@@ -32,6 +33,7 @@ var (
+ 	// ErrRepoNotFound is returned if the repository didn't exist on the
+ 	// remote side
+ 	ErrRepoNotFound = errors.New("Repository not found")
++	reURLScheme     = regexp.MustCompile(`^[^:]+://`)
+ )
+ 
+ // A Session is used to communicate with a V1 registry
+@@ -163,6 +165,18 @@ func (tr *authTransport) CancelRequest(req *http.Request) {
+ // NewSession creates a new session
+ // TODO(tiborvass): remove authConfig param once registry client v2 is vendored
+ func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *Endpoint) (r *Session, err error) {
++	if authConfig != nil && authConfig.ServerAddress != "" {
++		serverAddress := authConfig.ServerAddress
++		if !reURLScheme.MatchString(serverAddress) {
++			serverAddress = "http://" + serverAddress
++		}
++		parsed, err := url.Parse(serverAddress)
++		if err == nil && parsed.Host != endpoint.URL.Host {
++			logrus.Infof("authConfig does not conform to given endpoint (%s != %s)", parsed.Host, endpoint.URL.Host)
++			*authConfig = types.AuthConfig{}
++		}
++	}
++
+ 	r = &Session{
+ 		authConfig:    authConfig,
+ 		client:        client,
+-- 
+2.5.0
+

--- a/patch/0007-Add-dockerhooks-exec-custom-hooks-for-prestart-posts.patch
+++ b/patch/0007-Add-dockerhooks-exec-custom-hooks-for-prestart-posts.patch
@@ -1,0 +1,357 @@
+From 810f171a5bf39993618f42aba857c45d5fe5af09 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Wed, 9 Dec 2015 17:14:06 -0500
+Subject: [PATCH 07/13] Add dockerhooks exec custom hooks for prestart/poststop
+ containers
+
+With the addition of runc/hooks support we want to add a feature
+to allow third parties to run helper programs before a docker container
+gets started and just after the container finishes.
+
+For example we want to add a RegisterMachine hook.
+
+For systems that support systemd/RegisterMachine, this hook would register
+a machine to the machinectl.  machinectl could then list docker containers
+along with other virtulization environments like kvm, and systemd-nspawn
+containers. Overtime we would want to implement other machinectl features
+to get docker containers better integrated into the system and machinectl.
+
+Another example of a dockerhook might be for people wanting to do better logging
+of starting and stopping of containers.  For example have a log agent that
+records when a container starts and stops and then sends a message to a
+monitoring station.
+
+Dockerhooks reads directory in either /usr/lib/docker/hooks.d or
+/usr/libexec/docker/hooks.d to search for hooks, if the directory exists
+docker will execute the executables in this directory via runc/libcontainer i
+using PreStart and PostStop.  It will also send the config.json file as the
+second paramater.
+
+Signed-off-by: Sally O'Malley <somalley@redhat.com>
+Signed-off-by: Mrunal Patel <mrunalp@gmail.com>
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/client/info.go                                 |  2 +
+ daemon/execdriver/dockerhooks/dockerhooks_unix.go  | 90 ++++++++++++++++++++++
+ .../execdriver/dockerhooks/dockerhooks_windows.go  | 22 ++++++
+ daemon/execdriver/driver.go                        | 25 +++---
+ daemon/execdriver/native/create.go                 | 47 +++++++----
+ daemon/start.go                                    |  7 ++
+ docs/reference/commandline/info.md                 |  1 +
+ docs/userguide/labels-custom-metadata.md           |  1 +
+ man/docker-info.1.md                               |  1 +
+ 9 files changed, 168 insertions(+), 28 deletions(-)
+ create mode 100644 daemon/execdriver/dockerhooks/dockerhooks_unix.go
+ create mode 100644 daemon/execdriver/dockerhooks/dockerhooks_windows.go
+
+diff --git a/api/client/info.go b/api/client/info.go
+index 29e081d..bc25a66 100644
+--- a/api/client/info.go
++++ b/api/client/info.go
+@@ -4,6 +4,7 @@ import (
+ 	"fmt"
+ 
+ 	Cli "github.com/docker/docker/cli"
++	"github.com/docker/docker/daemon/execdriver/dockerhooks"
+ 	"github.com/docker/docker/pkg/ioutils"
+ 	flag "github.com/docker/docker/pkg/mflag"
+ 	"github.com/docker/go-units"
+@@ -57,6 +58,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
+ 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
+ 	ioutils.FprintfIfNotEmpty(cli.out, "OSType: %s\n", info.OSType)
+ 	ioutils.FprintfIfNotEmpty(cli.out, "Architecture: %s\n", info.Architecture)
++	fmt.Fprintf(cli.out, "Number of Docker Hooks: %d\n", dockerhooks.TotalHooks())
+ 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)
+ 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
+ 	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)
+diff --git a/daemon/execdriver/dockerhooks/dockerhooks_unix.go b/daemon/execdriver/dockerhooks/dockerhooks_unix.go
+new file mode 100644
+index 0000000..fda37c6
+--- /dev/null
++++ b/daemon/execdriver/dockerhooks/dockerhooks_unix.go
+@@ -0,0 +1,90 @@
++// +build !windows
++
++package dockerhooks
++
++import (
++	"bytes"
++	"encoding/json"
++	"io/ioutil"
++	"os"
++	"os/exec"
++	"path"
++
++	"github.com/docker/docker/utils"
++	"github.com/opencontainers/runc/libcontainer/configs"
++)
++
++// Prestart function will be called after container process is created but
++// before it is started
++func Prestart(state configs.HookState, configPath string) error {
++	hooks, hookDirPath, err := getHooks()
++	if err != nil {
++		return err
++	}
++	b, err := json.Marshal(state)
++	if err != nil {
++		return err
++	}
++	for _, item := range hooks {
++		if item.Mode().IsRegular() {
++			if err := runHook(path.Join(hookDirPath, item.Name()), "prestart", configPath, b); err != nil {
++				return err
++			}
++		}
++	}
++	return nil
++}
++
++// Poststop function will be called after container process has stopped but
++// before it is removed
++func Poststop(state configs.HookState, configPath string) error {
++	hooks, hookDirPath, err := getHooks()
++	if err != nil {
++		return err
++	}
++	b, err := json.Marshal(state)
++	if err != nil {
++		return err
++	}
++	for i := len(hooks) - 1; i >= 0; i-- {
++		fn := hooks[i].Name()
++		for _, item := range hooks {
++			if item.Mode().IsRegular() && fn == item.Name() {
++				if err := runHook(path.Join(hookDirPath, item.Name()), "poststop", configPath, b); err != nil {
++					return err
++				}
++			}
++		}
++	}
++	return nil
++}
++
++// TotalHooks returns the number of hooks to be used
++func TotalHooks() int {
++	hooks, _, _ := getHooks()
++	return len(hooks)
++}
++
++func getHooks() ([]os.FileInfo, string, error) {
++
++	hookDirPath := path.Join(path.Dir(utils.DockerInitPath("")), "hooks.d")
++	// find any hooks executables
++	if _, err := os.Stat(hookDirPath); os.IsNotExist(err) {
++		return nil, "", nil
++	}
++
++	hooks, err := ioutil.ReadDir(hookDirPath)
++	return hooks, hookDirPath, err
++}
++
++func runHook(hookFilePath string, hookType string, configPath string, stdinBytes []byte) error {
++	cmd := exec.Cmd{
++		Path: hookFilePath,
++		Args: []string{hookFilePath, hookType, configPath},
++		Env: []string{
++			"container=docker",
++		},
++		Stdin: bytes.NewReader(stdinBytes),
++	}
++	return cmd.Run()
++}
+diff --git a/daemon/execdriver/dockerhooks/dockerhooks_windows.go b/daemon/execdriver/dockerhooks/dockerhooks_windows.go
+new file mode 100644
+index 0000000..2061d94
+--- /dev/null
++++ b/daemon/execdriver/dockerhooks/dockerhooks_windows.go
+@@ -0,0 +1,22 @@
++package dockerhooks
++
++import (
++	"github.com/opencontainers/runc/libcontainer/configs"
++)
++
++// Prestart function will be called after container process is created but
++// before it is started
++func Prestart(state configs.HookState, configPath string) error {
++	return nil
++}
++
++// Poststop function will be called after container process has stopped but
++// before it is removed
++func Poststop(state configs.HookState, configPath string) error {
++	return nil
++}
++
++// TotalHooks returns the number of hooks to be used
++func TotalHooks() int {
++	return 0
++}
+diff --git a/daemon/execdriver/driver.go b/daemon/execdriver/driver.go
+index cb4ba62..d8ce774 100644
+--- a/daemon/execdriver/driver.go
++++ b/daemon/execdriver/driver.go
+@@ -126,16 +126,17 @@ type CommonProcessConfig struct {
+ // CommonCommand is the common platform agnostic part of the Command structure
+ // which wraps an os/exec.Cmd to add more metadata
+ type CommonCommand struct {
+-	ContainerPid  int           `json:"container_pid"` // the pid for the process inside a container
+-	ID            string        `json:"id"`
+-	InitPath      string        `json:"initpath"`    // dockerinit
+-	MountLabel    string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
+-	Mounts        []Mount       `json:"mounts"`
+-	Network       *Network      `json:"network"`
+-	ProcessConfig ProcessConfig `json:"process_config"` // Describes the init process of the container.
+-	ProcessLabel  string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
+-	Resources     *Resources    `json:"resources"`
+-	Rootfs        string        `json:"rootfs"` // root fs of the container
+-	WorkingDir    string        `json:"working_dir"`
+-	TmpDir        string        `json:"tmpdir"` // Directory used to store docker tmpdirs.
++	ContainerPid      int           `json:"container_pid"` // the pid for the process inside a container
++	ID                string        `json:"id"`
++	InitPath          string        `json:"initpath"`    // dockerinit
++	MountLabel        string        `json:"mount_label"` // TODO Windows. More involved, but can be factored out
++	Mounts            []Mount       `json:"mounts"`
++	Network           *Network      `json:"network"`
++	ProcessConfig     ProcessConfig `json:"process_config"` // Describes the init process of the container.
++	ProcessLabel      string        `json:"process_label"`  // TODO Windows. More involved, but can be factored out
++	Resources         *Resources    `json:"resources"`
++	Rootfs            string        `json:"rootfs"` // root fs of the container
++	WorkingDir        string        `json:"working_dir"`
++	TmpDir            string        `json:"tmpdir"` // Directory used to store docker tmpdirs.
++	ContainerJSONPath string        `json:"-"`
+ }
+diff --git a/daemon/execdriver/native/create.go b/daemon/execdriver/native/create.go
+index 0154801..9643ce3 100644
+--- a/daemon/execdriver/native/create.go
++++ b/daemon/execdriver/native/create.go
+@@ -9,6 +9,7 @@ import (
+ 	"syscall"
+ 
+ 	"github.com/docker/docker/daemon/execdriver"
++	"github.com/docker/docker/daemon/execdriver/dockerhooks"
+ 	derr "github.com/docker/docker/errors"
+ 	"github.com/docker/docker/pkg/mount"
+ 
+@@ -16,6 +17,8 @@ import (
+ 	"github.com/opencontainers/runc/libcontainer/apparmor"
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ 	"github.com/opencontainers/runc/libcontainer/devices"
++
++	"github.com/Sirupsen/logrus"
+ )
+ 
+ // createContainer populates and configures the container type with the
+@@ -143,26 +146,38 @@ func (d *Driver) createNetwork(container *configs.Config, c *execdriver.Command,
+ 		container.Namespaces.Add(configs.NEWNET, c.Network.NamespacePath)
+ 		return nil
+ 	}
++
++	logrus.Infof("Config: %+v", c)
++
++	container.Hooks = &configs.Hooks{}
++	container.Hooks.Prestart = append(container.Hooks.Prestart,
++		configs.NewFunctionHook(func(s configs.HookState) error {
++			return dockerhooks.Prestart(s, c.ContainerJSONPath)
++		}),
++	)
++	container.Hooks.Poststop = append(container.Hooks.Poststop,
++		configs.NewFunctionHook(func(s configs.HookState) error {
++			return dockerhooks.Poststop(s, c.ContainerJSONPath)
++		}),
++	)
++
+ 	// only set up prestart hook if the namespace path is not set (this should be
+ 	// all cases *except* for --net=host shared networking)
+-	container.Hooks = &configs.Hooks{
+-		Prestart: []configs.Hook{
+-			configs.NewFunctionHook(func(s configs.HookState) error {
+-				if len(hooks.PreStart) > 0 {
+-					for _, fnHook := range hooks.PreStart {
+-						// A closed channel for OOM is returned here as it will be
+-						// non-blocking and return the correct result when read.
+-						chOOM := make(chan struct{})
+-						close(chOOM)
+-						if err := fnHook(&c.ProcessConfig, s.Pid, chOOM); err != nil {
+-							return err
+-						}
++	container.Hooks.Prestart = append(container.Hooks.Prestart,
++		configs.NewFunctionHook(func(s configs.HookState) error {
++			if len(hooks.PreStart) > 0 {
++				for _, fnHook := range hooks.PreStart {
++					// A closed channel for OOM is returned here as it will be
++					// non-blocking and return the correct result when read.
++					chOOM := make(chan struct{})
++					close(chOOM)
++					if err := fnHook(&c.ProcessConfig, s.Pid, chOOM); err != nil {
++						return err
+ 					}
+ 				}
+-				return nil
+-			}),
+-		},
+-	}
++			}
++			return nil
++		}))
+ 	return nil
+ }
+ 
+diff --git a/daemon/start.go b/daemon/start.go
+index 90b745e..6b2c739 100644
+--- a/daemon/start.go
++++ b/daemon/start.go
+@@ -132,6 +132,13 @@ func (daemon *Daemon) containerStart(container *container.Container) (err error)
+ 	mounts = append(mounts, container.TmpfsMounts()...)
+ 
+ 	container.Command.Mounts = mounts
++
++	jsonPath, err := container.ConfigPath()
++	if err != nil {
++		return err
++	}
++	container.Command.ContainerJSONPath = jsonPath
++
+ 	if err := daemon.waitForStart(container); err != nil {
+ 		return err
+ 	}
+diff --git a/docs/reference/commandline/info.md b/docs/reference/commandline/info.md
+index f489a9b..1fba9e8 100644
+--- a/docs/reference/commandline/info.md
++++ b/docs/reference/commandline/info.md
+@@ -37,6 +37,7 @@ For example:
+     OSType: linux
+     Architecture: x86_64
+     Operating System: Ubuntu 15.04
++    Number of Hooks: 2
+     CPUs: 24
+     Total Memory: 62.86 GiB
+     Name: docker
+diff --git a/docs/userguide/labels-custom-metadata.md b/docs/userguide/labels-custom-metadata.md
+index e4ac7c4..c31aa21 100644
+--- a/docs/userguide/labels-custom-metadata.md
++++ b/docs/userguide/labels-custom-metadata.md
+@@ -198,6 +198,7 @@ These labels appear as part of the `docker info` output for the daemon:
+     Logging Driver: json-file
+     Kernel Version: 3.19.0-22-generic
+     Operating System: Ubuntu 15.04
++    Number of Hooks: 2
+     CPUs: 24
+     Total Memory: 62.86 GiB
+     Name: docker
+diff --git a/man/docker-info.1.md b/man/docker-info.1.md
+index ae04e49..eeb90ae 100644
+--- a/man/docker-info.1.md
++++ b/man/docker-info.1.md
+@@ -46,6 +46,7 @@ Here is a sample output:
+     Operating System: Ubuntu 14.04 LTS
+     OSType: linux
+     Architecture: x86_64
++    Number of Hooks: 2
+     CPUs: 1
+     Total Memory: 2 GiB
+ 
+-- 
+2.5.0
+

--- a/patch/0008-System-logging-for-docker-daemon-API-calls.patch
+++ b/patch/0008-System-logging-for-docker-daemon-API-calls.patch
@@ -1,0 +1,408 @@
+From 6728246c3bf2986be0628a111fde24ef32dc713b Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Mon, 14 Dec 2015 17:16:20 -0500
+Subject: [PATCH 08/13] System logging for docker daemon API calls
+
+As part of handling the middleware wrappers around API calls requested
+by clients, log information about the request and the user's identity
+(UID, login name if we can find it, and PID) to syslog.
+
+Signed-off-by: Alec Benson <albenson@redhat.com> (github: alecbenson)
+Signed-off-by: Nalin Dahyabhai <nalin@redhat.com> (github: nalind)
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+
+System logging for docker daemon API calls
+
+As part of handling the middleware wrappers around API calls requested
+by clients, log information about the request and the user's identity
+(UID, login name if we can find it, and PID) to syslog.
+
+Signed-off-by: Alec Benson <albenson@redhat.com> (github: alecbenson)
+Signed-off-by: Nalin Dahyabhai <nalin@redhat.com> (github: nalind)
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/server/credentials_linux.go   | 253 ++++++++++++++++++++++++++++++++++++++
+ api/server/credentials_windows.go |  10 ++
+ api/server/middleware.go          |  13 +-
+ api/server/server.go              |   6 +
+ docker/daemon.go                  |  11 +-
+ 5 files changed, 288 insertions(+), 5 deletions(-)
+ create mode 100644 api/server/credentials_linux.go
+ create mode 100644 api/server/credentials_windows.go
+
+diff --git a/api/server/credentials_linux.go b/api/server/credentials_linux.go
+new file mode 100644
+index 0000000..583aa1a
+--- /dev/null
++++ b/api/server/credentials_linux.go
+@@ -0,0 +1,253 @@
++// +build linux
++
++package server
++
++import (
++	"bytes"
++	"fmt"
++	"io/ioutil"
++	"net/http"
++	"net/url"
++	"os/user"
++	"path"
++	"reflect"
++	"strconv"
++	"syscall"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/docker/api/types/versions/v1p20"
++	"github.com/docker/docker/container"
++	"github.com/docker/docker/pkg/version"
++)
++
++//Gets the file descriptor
++func getFdFromWriter(w http.ResponseWriter) int {
++	//We must use introspection to pull the
++	//connection from the ResponseWriter object
++	//This is because the connection object is not exported by the writer.
++	writerVal := reflect.Indirect(reflect.ValueOf(w))
++	if writerVal.Kind() != reflect.Struct {
++		logrus.Warn("ResponseWriter is not a struct")
++		return -1
++	}
++	//Get the underlying http connection
++	httpconn := writerVal.FieldByName("conn")
++	if !httpconn.IsValid() {
++		logrus.Warn("ResponseWriter does not contain a field named conn")
++		return -1
++	}
++	httpconnVal := reflect.Indirect(httpconn)
++	if httpconnVal.Kind() != reflect.Struct {
++		logrus.Warn("conn is not an interface to a struct")
++		return -1
++	}
++	//Get the underlying tcp connection
++	rwcPtr := httpconnVal.FieldByName("rwc").Elem()
++	rwc := reflect.Indirect(rwcPtr)
++	if rwc.Kind() != reflect.Struct {
++		logrus.Warn("conn is not an interface to a struct")
++		return -1
++	}
++	tcpconn := reflect.Indirect(rwc.FieldByName("conn"))
++	//Grab the underyling netfd
++	if tcpconn.Kind() != reflect.Struct {
++		logrus.Warn("tcpconn is not a struct")
++		return -1
++	}
++	netfd := reflect.Indirect(tcpconn.FieldByName("fd"))
++	//Grab sysfd
++	if netfd.Kind() != reflect.Struct {
++		logrus.Warn("fd is not a struct")
++		return -1
++	}
++	sysfd := netfd.FieldByName("sysfd")
++	//Finally, we have the fd
++	return int(sysfd.Int())
++}
++
++//Gets the ucred given an http response writer
++func getUcred(fd int) (*syscall.Ucred, error) {
++	return syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
++}
++
++//Gets the client's loginuid
++func getLoginUID(ucred *syscall.Ucred, fd int) (int, error) {
++	if _, err := syscall.Getpeername(fd); err != nil {
++		logrus.Errorf("Socket appears to have closed: %v", err)
++		return -1, err
++	}
++	loginuid, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/loginuid", ucred.Pid))
++	if err != nil {
++		logrus.Errorf("Error reading loginuid: %v", err)
++		return -1, err
++	}
++	loginuidInt, err := strconv.Atoi(string(loginuid))
++	if err != nil {
++		logrus.Errorf("Failed to convert loginuid to int: %v", err)
++	}
++	return loginuidInt, nil
++}
++
++//Given a loginUID, retrieves the current username
++func getpwuid(loginUID int) (string, error) {
++	pwd, err := user.LookupId(strconv.Itoa(loginUID))
++	if err != nil {
++		logrus.Errorf("Failed to get pwuid struct: %v", err)
++		return "", err
++	}
++	if pwd == nil {
++		return "", user.UnknownUserIdError(loginUID)
++	}
++	name := pwd.Username
++	return name, nil
++}
++
++//Retrieves the container and "action" (start, stop, kill, etc) from the http request
++func (s *Server) parseRequest(r *http.Request) (string, *container.Container) {
++	var (
++		containerID string
++		action      string
++	)
++	requrl := r.RequestURI
++	parsedurl, err := url.Parse(requrl)
++	if err != nil {
++		return "?", nil
++	}
++
++	switch r.Method {
++	//Delete requests do not explicitly state the action, so we check the HTTP method instead
++	case "DELETE":
++		action = "remove"
++		containerID = path.Base(parsedurl.Path)
++	default:
++		action = path.Base(parsedurl.Path)
++		containerID = path.Base(path.Dir(parsedurl.Path))
++	}
++
++	if s.daemon != nil {
++		c, err := s.daemon.GetContainer(containerID)
++		if err == nil {
++			return action, c
++		}
++	}
++	return action, nil
++}
++
++//Traverses the config struct and grabs non-standard values for logging
++func parseConfig(config interface{}) string {
++	configReflect := reflect.Indirect(reflect.ValueOf(config))
++	var result bytes.Buffer
++	for index := 0; index < configReflect.NumField(); index++ {
++		val := reflect.Indirect(configReflect.Field(index))
++		//Get the zero value of the struct's field
++		if val.IsValid() {
++			zeroVal := reflect.Zero(val.Type()).Interface()
++			//If the configuration value is not a zero value, then we store it
++			//We use deep equal here because some types cannot be compared with the standard equality operators
++			if val.Kind() == reflect.Bool || !reflect.DeepEqual(zeroVal, val.Interface()) {
++				fieldName := configReflect.Type().Field(index).Name
++				if result.Len() > 0 {
++					result.WriteString(", ")
++				}
++				fmt.Fprintf(&result, "%s=%+v", fieldName, val.Interface())
++			}
++		}
++	}
++	return result.String()
++}
++
++//Constructs a partial log message containing the container's configuration settings
++func generateContainerConfigMsg(c *container.Container, j *v1p20.ContainerJSON) string {
++	if c != nil && j != nil {
++		configStripped := parseConfig(*c.Config)
++		hostConfigStripped := parseConfig(*j.HostConfig)
++		return fmt.Sprintf("Config={%v}, HostConfig={%v}", configStripped, hostConfigStripped)
++	}
++	return ""
++}
++
++//LogAction logs a docker API function and records the user that initiated the request using the authentication results
++func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
++	var (
++		message  string
++		username string
++		loginuid = -1
++	)
++
++	action, c := s.parseRequest(r)
++
++	switch action {
++	case "start":
++		if s.daemon != nil && c != nil {
++			version := version.Version("1.20")
++			inspect, err := s.daemon.ContainerInspect(c.ID, false, version)
++			if err == nil {
++				message = ", " + generateContainerConfigMsg(c, inspect.(*v1p20.ContainerJSON))
++			}
++		}
++		fallthrough
++	default:
++		//Get user credentials
++		fd := getFdFromWriter(w)
++		server, err := syscall.Getsockname(fd)
++		if err != nil {
++			logrus.Errorf("Unable to read peer creds and server socket address: %v", err)
++			message = "LoginUID unknown, PID unknown" + message
++			break
++		}
++		if _, isUnix := server.(*syscall.SockaddrUnix); !isUnix {
++			logrus.Debug("Unable to read peer creds: server socket is not a Unix socket")
++			message = "LoginUID unknown, PID unknown" + message
++			break
++		}
++		ucred, err := getUcred(fd)
++		if err != nil {
++			logrus.Errorf("Unable to read peer creds: %v", err)
++			message = "LoginUID unknown, PID unknown" + message
++			break
++		}
++		message = fmt.Sprintf("PID=%v", ucred.Pid) + message
++
++		//Get user loginuid
++		loginuid, err = getLoginUID(ucred, fd)
++		if err != nil {
++			break
++		}
++		message = fmt.Sprintf("LoginUID=%v, %s", loginuid, message)
++		if loginuid == 0xffffffff { // -1 means no login user
++			//No login UID is set, so no point in looking up a name
++			break
++		}
++
++		//Get username
++		username, err = getpwuid(loginuid)
++		if err != nil {
++			break
++		}
++
++		message = fmt.Sprintf("Username=%v, %s", username, message)
++	}
++
++	//Log the container ID being affected if it exists
++	if c != nil {
++		message = fmt.Sprintf("ID=%v, %s", c.ID, message)
++	}
++	message = fmt.Sprintf("{Action=%v, %s}", action, message)
++	// Log info messages at Debug Level
++	// Log messages that change state at Info level
++	switch action {
++	case "info":
++	case "images":
++	case "version":
++	case "json":
++	case "search":
++	case "stats":
++	case "events":
++	case "history":
++		logrus.Debug(message)
++		fallthrough
++	default:
++		logrus.Info(message)
++	}
++	return nil
++}
+diff --git a/api/server/credentials_windows.go b/api/server/credentials_windows.go
+new file mode 100644
+index 0000000..c1abe3c
+--- /dev/null
++++ b/api/server/credentials_windows.go
+@@ -0,0 +1,10 @@
++// +build windows
++
++package server
++
++import "net/http"
++
++//LogAction is unsupported in windows environments
++func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
++	return nil
++}
+diff --git a/api/server/middleware.go b/api/server/middleware.go
+index 3bb6419..3cc2402 100644
+--- a/api/server/middleware.go
++++ b/api/server/middleware.go
+@@ -137,6 +137,14 @@ func versionMiddleware(handler httputils.APIFunc) httputils.APIFunc {
+ 	}
+ }
+ 
++// auditMiddleware logs actions and information about containers when they're started.
++func (s *Server) auditMiddleware(handler httputils.APIFunc) httputils.APIFunc {
++	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
++		s.LogAction(w, r)
++		return handler(ctx, w, r, vars)
++	}
++}
++
+ // handleWithGlobalMiddlwares wraps the handler function for a request with
+ // the server's global middlewares. The order of the middlewares is backwards,
+ // meaning that the first in the list will be evaluated last.
+@@ -146,13 +154,16 @@ func versionMiddleware(handler httputils.APIFunc) httputils.APIFunc {
+ //	s.loggingMiddleware(
+ //		s.userAgentMiddleware(
+ //			s.corsMiddleware(
+-//				versionMiddleware(s.getContainersName)
++//				s.versionMiddleware(
++//					s.auditMiddleware(s.getContainersName)
++//				)
+ //			)
+ //		)
+ //	)
+ // )
+ func (s *Server) handleWithGlobalMiddlewares(handler httputils.APIFunc) httputils.APIFunc {
+ 	middlewares := []middleware{
++		s.auditMiddleware,
+ 		versionMiddleware,
+ 		s.corsMiddleware,
+ 		s.userAgentMiddleware,
+diff --git a/api/server/server.go b/api/server/server.go
+index 218456e..3155ef7 100644
+--- a/api/server/server.go
++++ b/api/server/server.go
+@@ -42,6 +42,7 @@ type Config struct {
+ // Server contains instance details for the server
+ type Server struct {
+ 	cfg          *Config
++	daemon       *daemon.Daemon
+ 	servers      []*HTTPServer
+ 	routers      []router.Router
+ 	authZPlugins []authorization.Plugin
+@@ -79,6 +80,11 @@ func (s *Server) Close() {
+ 	}
+ }
+ 
++// SetDaemon initializes the daemon field
++func (s *Server) SetDaemon(daemon *daemon.Daemon) {
++	s.daemon = daemon
++}
++
+ // ServeAPI loops through all initialized servers and spawns goroutine
+ // with Server method for each. It sets CreateMux() as Handler also.
+ func (s *Server) ServeAPI() error {
+diff --git a/docker/daemon.go b/docker/daemon.go
+index 6aac30b..5410aa2 100644
+--- a/docker/daemon.go
++++ b/docker/daemon.go
+@@ -213,16 +213,17 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
+ 		}
+ 		serverConfig.Addrs = append(serverConfig.Addrs, apiserver.Addr{Proto: protoAddrParts[0], Addr: protoAddrParts[1]})
+ 	}
+-	api, err := apiserver.New(serverConfig)
+-	if err != nil {
+-		logrus.Fatal(err)
+-	}
+ 
+ 	if err := migrateKey(); err != nil {
+ 		logrus.Fatal(err)
+ 	}
+ 	cli.TrustKeyPath = commonFlags.TrustKey
+ 
++	api, err := apiserver.New(serverConfig)
++	if err != nil {
++		logrus.Fatal(err)
++	}
++
+ 	registryService := registry.NewService(cli.registryOptions)
+ 	d, err := daemon.NewDaemon(cli.Config, registryService)
+ 	if err != nil {
+@@ -236,6 +237,8 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
+ 
+ 	logrus.Info("Daemon has completed initialization")
+ 
++	api.SetDaemon(d)
++
+ 	logrus.WithFields(logrus.Fields{
+ 		"version":     dockerversion.Version,
+ 		"commit":      dockerversion.GitCommit,
+-- 
+2.5.0
+

--- a/patch/0009-Audit-logging-support-for-daemon-API-calls.patch
+++ b/patch/0009-Audit-logging-support-for-daemon-API-calls.patch
@@ -1,0 +1,399 @@
+From ad863f5722271e343cb159c1fb4f7ac1355fc40a Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Wed, 16 Dec 2015 08:35:32 -0500
+Subject: [PATCH 09/13] Audit logging support for daemon API calls
+
+Signed-off-by: Alec Benson <albenson@redhat.com> (github: alecbenson)
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ Dockerfile                                    |  1 +
+ api/server/credentials_linux.go               | 49 +++++++++++++++
+ contrib/builder/deb/debian-jessie/Dockerfile  |  2 +-
+ contrib/builder/deb/debian-stretch/Dockerfile |  2 +-
+ contrib/builder/deb/debian-wheezy/Dockerfile  |  2 +-
+ contrib/builder/deb/generate.sh               |  1 +
+ contrib/builder/deb/ubuntu-precise/Dockerfile |  2 +-
+ contrib/builder/deb/ubuntu-trusty/Dockerfile  |  2 +-
+ contrib/builder/deb/ubuntu-vivid/Dockerfile   |  2 +-
+ contrib/builder/deb/ubuntu-wily/Dockerfile    |  2 +-
+ contrib/builder/rpm/centos-7/Dockerfile       |  2 +-
+ contrib/builder/rpm/fedora-21/Dockerfile      |  2 +-
+ contrib/builder/rpm/fedora-22/Dockerfile      |  2 +-
+ contrib/builder/rpm/fedora-23/Dockerfile      |  2 +-
+ contrib/builder/rpm/generate.sh               |  1 +
+ contrib/builder/rpm/opensuse-13.2/Dockerfile  |  2 +-
+ contrib/builder/rpm/oraclelinux-7/Dockerfile  |  2 +-
+ pkg/audit/audit_linux.go                      | 86 +++++++++++++++++++++++++++
+ 18 files changed, 151 insertions(+), 13 deletions(-)
+ create mode 100644 pkg/audit/audit_linux.go
+
+diff --git a/Dockerfile b/Dockerfile
+index 1a503a7..91e3888 100644
+--- a/Dockerfile
++++ b/Dockerfile
+@@ -52,6 +52,7 @@ RUN apt-get update && apt-get install -y \
+ 	iptables \
+ 	jq \
+ 	libapparmor-dev \
++	libaudit-dev \
+ 	libcap-dev \
+ 	libltdl-dev \
+ 	libsqlite3-dev \
+diff --git a/api/server/credentials_linux.go b/api/server/credentials_linux.go
+index 583aa1a..db8c4d8 100644
+--- a/api/server/credentials_linux.go
++++ b/api/server/credentials_linux.go
+@@ -17,6 +17,7 @@ import (
+ 	"github.com/Sirupsen/logrus"
+ 	"github.com/docker/docker/api/types/versions/v1p20"
+ 	"github.com/docker/docker/container"
++	"github.com/docker/docker/pkg/audit"
+ 	"github.com/docker/docker/pkg/version"
+ )
+ 
+@@ -248,6 +249,54 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
+ 		fallthrough
+ 	default:
+ 		logrus.Info(message)
++		logAuditlog(c, action, username, loginuid, true)
+ 	}
+ 	return nil
+ }
++
++//Logs an API event to the audit log
++func logAuditlog(c *container.Container, action string, username string, loginuid int, success bool) {
++	virt := audit.AuditVirtControl
++	vm := "?"
++	vmPid := "?"
++	exe := "?"
++	hostname := "?"
++	user := "?"
++	auid := "?"
++
++	if c != nil {
++		vm = c.Config.Image
++		vmPid = fmt.Sprint(c.State.Pid)
++		exe = c.Path
++		hostname = c.Config.Hostname
++	}
++
++	if username != "" {
++		user = username
++	}
++
++	if loginuid != -1 {
++		auid = fmt.Sprint(loginuid)
++	}
++
++	vars := map[string]string{
++		"op":       action,
++		"reason":   "api",
++		"vm":       vm,
++		"vm-pid":   vmPid,
++		"user":     user,
++		"auid":     auid,
++		"exe":      exe,
++		"hostname": hostname,
++	}
++
++	//Encoding is a function of libaudit that ensures
++	//that the audit values contain only approved characters.
++	for key, value := range vars {
++		if audit.ValueNeedsEncoding(value) {
++			vars[key] = audit.EncodeNVString(key, value)
++		}
++	}
++	message := audit.FormatVars(vars)
++	audit.LogUserEvent(virt, message, success)
++}
+diff --git a/contrib/builder/deb/debian-jessie/Dockerfile b/contrib/builder/deb/debian-jessie/Dockerfile
+index 5ce3989..f330ba2 100644
+--- a/contrib/builder/deb/debian-jessie/Dockerfile
++++ b/contrib/builder/deb/debian-jessie/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM debian:jessie
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/deb/debian-stretch/Dockerfile b/contrib/builder/deb/debian-stretch/Dockerfile
+index efc9e00..150e1d0 100644
+--- a/contrib/builder/deb/debian-stretch/Dockerfile
++++ b/contrib/builder/deb/debian-stretch/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM debian:stretch
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV GO_VERSION 1.5.2
+ RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+diff --git a/contrib/builder/deb/debian-wheezy/Dockerfile b/contrib/builder/deb/debian-wheezy/Dockerfile
+index 67d6d43..8ffae0c 100644
+--- a/contrib/builder/deb/debian-wheezy/Dockerfile
++++ b/contrib/builder/deb/debian-wheezy/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM debian:wheezy-backports
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools/wheezy-backports build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev  libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV GO_VERSION 1.5.2
+ RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+diff --git a/contrib/builder/deb/generate.sh b/contrib/builder/deb/generate.sh
+index 18d0752..2fe0e9e 100755
+--- a/contrib/builder/deb/generate.sh
++++ b/contrib/builder/deb/generate.sh
+@@ -55,6 +55,7 @@ for version in "${versions[@]}"; do
+ 		dh-systemd # for systemd debhelper integration
+ 		git # for "git commit" info in "docker -v"
+ 		libapparmor-dev # for "sys/apparmor.h"
++		libaudit-dev # for "libaudit.h" and libaudit.so
+ 		libdevmapper-dev # for "libdevmapper.h"
+ 		libltdl-dev # for pkcs11 "ltdl.h"
+ 		libsqlite3-dev # for "sqlite3.h"
+diff --git a/contrib/builder/deb/ubuntu-precise/Dockerfile b/contrib/builder/deb/ubuntu-precise/Dockerfile
+index daf7668..bba2a42 100644
+--- a/contrib/builder/deb/ubuntu-precise/Dockerfile
++++ b/contrib/builder/deb/ubuntu-precise/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM ubuntu:precise
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libltdl-dev libsqlite3-dev  --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion  build-essential curl ca-certificates debhelper dh-apparmor  git libapparmor-dev  libaudit-dev libltdl-dev libsqlite3-dev  --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV GO_VERSION 1.5.2
+ RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+diff --git a/contrib/builder/deb/ubuntu-trusty/Dockerfile b/contrib/builder/deb/ubuntu-trusty/Dockerfile
+index ae6ef44..2fbef0d 100644
+--- a/contrib/builder/deb/ubuntu-trusty/Dockerfile
++++ b/contrib/builder/deb/ubuntu-trusty/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM ubuntu:trusty
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/deb/ubuntu-vivid/Dockerfile b/contrib/builder/deb/ubuntu-vivid/Dockerfile
+index fd8d029..f228a52 100644
+--- a/contrib/builder/deb/ubuntu-vivid/Dockerfile
++++ b/contrib/builder/deb/ubuntu-vivid/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM ubuntu:vivid
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-journal-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/deb/ubuntu-wily/Dockerfile b/contrib/builder/deb/ubuntu-wily/Dockerfile
+index 9414832..9c0033a 100644
+--- a/contrib/builder/deb/ubuntu-wily/Dockerfile
++++ b/contrib/builder/deb/ubuntu-wily/Dockerfile
+@@ -4,7 +4,7 @@
+ 
+ FROM ubuntu:wily
+ 
+-RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
++RUN apt-get update && apt-get install -y apparmor bash-completion btrfs-tools build-essential curl ca-certificates debhelper dh-apparmor dh-systemd git libapparmor-dev libaudit-dev libdevmapper-dev libltdl-dev libsqlite3-dev libseccomp-dev libsystemd-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
+ 
+ ENV GO_VERSION 1.5.2
+ RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+diff --git a/contrib/builder/rpm/centos-7/Dockerfile b/contrib/builder/rpm/centos-7/Dockerfile
+index 0a1fdde..0cc92a6 100644
+--- a/contrib/builder/rpm/centos-7/Dockerfile
++++ b/contrib/builder/rpm/centos-7/Dockerfile
+@@ -6,7 +6,7 @@ FROM centos:7
+ 
+ RUN yum groupinstall -y "Development Tools"
+ RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
+-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/rpm/fedora-21/Dockerfile b/contrib/builder/rpm/fedora-21/Dockerfile
+index a392a2f..daba5e1 100644
+--- a/contrib/builder/rpm/fedora-21/Dockerfile
++++ b/contrib/builder/rpm/fedora-21/Dockerfile
+@@ -5,7 +5,7 @@
+ FROM fedora:21
+ 
+ RUN yum install -y @development-tools fedora-packager
+-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/rpm/fedora-22/Dockerfile b/contrib/builder/rpm/fedora-22/Dockerfile
+index ff88ce1..425452b 100644
+--- a/contrib/builder/rpm/fedora-22/Dockerfile
++++ b/contrib/builder/rpm/fedora-22/Dockerfile
+@@ -5,7 +5,7 @@
+ FROM fedora:22
+ 
+ RUN dnf install -y @development-tools fedora-packager
+-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/rpm/fedora-23/Dockerfile b/contrib/builder/rpm/fedora-23/Dockerfile
+index 1596714..4f334a9 100644
+--- a/contrib/builder/rpm/fedora-23/Dockerfile
++++ b/contrib/builder/rpm/fedora-23/Dockerfile
+@@ -5,7 +5,7 @@
+ FROM fedora:23
+ 
+ RUN dnf install -y @development-tools fedora-packager
+-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/contrib/builder/rpm/generate.sh b/contrib/builder/rpm/generate.sh
+index 18ba550..38c5e9b 100755
+--- a/contrib/builder/rpm/generate.sh
++++ b/contrib/builder/rpm/generate.sh
+@@ -64,6 +64,7 @@ for version in "${versions[@]}"; do
+ 
+ 	# this list is sorted alphabetically; please keep it that way
+ 	packages=(
++		audit-libs-devel audit-libs-static # for "libaudit.h" and libaudit.so/libaudit.a
+ 		btrfs-progs-devel # for "btrfs/ioctl.h" (and "version.h" if possible)
+ 		device-mapper-devel # for "libdevmapper.h"
+ 		glibc-static
+diff --git a/contrib/builder/rpm/opensuse-13.2/Dockerfile b/contrib/builder/rpm/opensuse-13.2/Dockerfile
+index 2c4e7c6..5cb62d8 100644
+--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
++++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
+@@ -5,7 +5,7 @@
+ FROM opensuse:13.2
+ 
+ RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
+-RUN zypper --non-interactive install libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN zypper --non-interactive install libaudit-dev libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV GO_VERSION 1.5.2
+ RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
+diff --git a/contrib/builder/rpm/oraclelinux-7/Dockerfile b/contrib/builder/rpm/oraclelinux-7/Dockerfile
+index 3d6a6b3..8d8cd23 100644
+--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
++++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
+@@ -5,7 +5,7 @@
+ FROM oraclelinux:7
+ 
+ RUN yum groupinstall -y "Development Tools"
+-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
++RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ 
+ ENV SECCOMP_VERSION v2.2.3
+ RUN buildDeps=' \
+diff --git a/pkg/audit/audit_linux.go b/pkg/audit/audit_linux.go
+new file mode 100644
+index 0000000..1409fec
+--- /dev/null
++++ b/pkg/audit/audit_linux.go
+@@ -0,0 +1,86 @@
++// +build linux
++
++/*
++  The audit package is a go bindings to libaudit that only allows for
++  logging audit events.
++
++  Author Steve Grubb <sgrubb@redhat.com>
++*/
++
++package audit
++
++// #cgo LDFLAGS: -laudit
++// #include "libaudit.h"
++// #include <unistd.h>
++// #include <stdlib.h>
++// #include <string.h>
++// #include <stdio.h>
++import "C"
++
++import (
++	"fmt"
++	"unsafe"
++)
++
++// viraudit.c: auditing support
++// AUDIT_VIRT_CONTROL, AUDIT_VIRT_RESOURCE, AUDIT_VIRT_MACHINE_ID
++const (
++	AuditVirtControl = 2500
++	VirtResource     = 2501
++	VirtMachineID    = 2502
++)
++
++// ValueNeedsEncoding returns true if audit value needs encoding
++func ValueNeedsEncoding(str string) bool {
++	cstr := C.CString(str)
++	defer C.free(unsafe.Pointer(cstr))
++	len := C.strlen(cstr)
++
++	res, _ := C.audit_value_needs_encoding(cstr, C.uint(len))
++	if res != 0 {
++		return true
++	}
++	return false
++}
++
++// EncodeNVString returns string of encoded audit value
++func EncodeNVString(name string, value string) string {
++	cname := C.CString(name)
++	cval := C.CString(value)
++
++	cres := C.audit_encode_nv_string(cname, cval, 0)
++
++	C.free(unsafe.Pointer(cname))
++	C.free(unsafe.Pointer(cval))
++	defer C.free(unsafe.Pointer(cres))
++
++	return C.GoString(cres)
++}
++
++// LogUserEvent logs a generate user message
++func LogUserEvent(eventType int, message string, result bool) error {
++	var r int
++	fd := C.audit_open()
++	defer C.close(fd)
++	if result {
++		r = 1
++	} else {
++		r = 0
++	}
++	if fd > 0 {
++		cmsg := C.CString(message)
++		defer C.free(unsafe.Pointer(cmsg))
++		_, err := C.audit_log_user_message(fd, C.int(eventType), cmsg, nil, nil, nil, C.int(r))
++		return err
++	}
++	return nil
++}
++
++// FormatVars formats map to a space separated list of Key=Value pairs
++func FormatVars(vars map[string]string) string {
++	var result string
++	for key, value := range vars {
++		result += fmt.Sprintf("%s=%s ", key, value)
++	}
++	return result
++}
+-- 
+2.5.0
+

--- a/patch/0010-Add-volume-support-to-docker-build.patch
+++ b/patch/0010-Add-volume-support-to-docker-build.patch
@@ -1,0 +1,395 @@
+From f6466fd7da752aac1cd379a3031ecff3bbe35f34 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Wed, 16 Dec 2015 14:12:22 -0500
+Subject: [PATCH 10/13] Add volume support to docker build
+
+This patch adds the ability to add bind mounts at build-time.
+This will be helpful in supporting builds with host files and secrets.
+The `--volume|-v` flag is added for this purpose. Trying to define a
+volume (ala `docker run`) errors out. Each bind mounts' mode will be
+read-only and it will preserve any SELinux label which was defined via
+the cli (`:[z,Z]`). Defining a read-write mode (`:rw`) will just print
+a warning in the build output and the actual mode will be changed to
+read-only.
+
+Signed-off-by: Antonio Murdaca <runcom@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/client/build.go                      |  20 +++++
+ api/client/lib/image_build.go            |   6 ++
+ api/server/router/local/image.go         |   9 ++
+ api/types/client.go                      |   1 +
+ builder/dockerfile/builder.go            |   1 +
+ builder/dockerfile/internals.go          |  37 +++++++++
+ docs/reference/commandline/build.md      |   1 +
+ integration-cli/docker_cli_build_test.go | 138 +++++++++++++++++++++++++++++++
+ man/docker-build.1.md                    |   7 ++
+ 9 files changed, 220 insertions(+)
+
+diff --git a/api/client/build.go b/api/client/build.go
+index d0930e1..47c5689 100644
+--- a/api/client/build.go
++++ b/api/client/build.go
+@@ -32,6 +32,7 @@ import (
+ 	"github.com/docker/docker/registry"
+ 	tagpkg "github.com/docker/docker/tag"
+ 	"github.com/docker/docker/utils"
++	"github.com/docker/docker/volume"
+ 	"github.com/docker/go-units"
+ )
+ 
+@@ -63,6 +64,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
+ 	cmd.Var(&flBuildArg, []string{"-build-arg"}, "Set build-time variables")
+ 	isolation := cmd.String([]string{"-isolation"}, "", "Container isolation level")
+ 
++	flBuildVolumes := opts.NewListOpts(nil)
++	cmd.Var(&flBuildVolumes, []string{"v", "-volume"}, "Set build-time bind mounts")
++
+ 	ulimits := make(map[string]*ulimit.Ulimit)
+ 	flUlimits := opts.NewUlimitOpt(&ulimits)
+ 	cmd.Var(flUlimits, []string{"-ulimit"}, "Ulimit options")
+@@ -202,6 +206,21 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
+ 		remoteContext = cmd.Arg(0)
+ 	}
+ 
++	var binds []string
++	// add any bind targets to the list of container volumes
++	for bind := range flBuildVolumes.GetMap() {
++		if arr := volume.SplitN(bind, 2); len(arr) > 1 {
++			// after creating the bind mount we want to delete it from the flBuildVolumes values because
++			// we do not want bind mounts being committed to image configs
++			binds = append(binds, bind)
++			flBuildVolumes.Delete(bind)
++		}
++	}
++
++	if len(flBuildVolumes.GetMap()) > 0 {
++		return fmt.Errorf("Volumes aren't supported in docker build. Please use only bind mounts.")
++	}
++
+ 	options := types.ImageBuildOptions{
+ 		Context:        body,
+ 		Memory:         memory,
+@@ -225,6 +244,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
+ 		Ulimits:        flUlimits.GetList(),
+ 		BuildArgs:      flBuildArg.GetAll(),
+ 		AuthConfigs:    cli.configFile.AuthConfigs,
++		Binds:          binds,
+ 	}
+ 
+ 	response, err := cli.client.ImageBuild(options)
+diff --git a/api/client/lib/image_build.go b/api/client/lib/image_build.go
+index ffe8b42..be3a6a0 100644
+--- a/api/client/lib/image_build.go
++++ b/api/client/lib/image_build.go
+@@ -108,6 +108,12 @@ func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, erro
+ 	}
+ 	query.Set("buildargs", string(buildArgsJSON))
+ 
++	buildBindsJSON, err := json.Marshal(options.Binds)
++	if err != nil {
++		return query, err
++	}
++	query.Set("buildbinds", string(buildBindsJSON))
++
+ 	return query, nil
+ }
+ 
+diff --git a/api/server/router/local/image.go b/api/server/router/local/image.go
+index ce3ec3c..25f315a 100644
+--- a/api/server/router/local/image.go
++++ b/api/server/router/local/image.go
+@@ -405,6 +405,15 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
+ 		buildConfig.BuildArgs = buildArgs
+ 	}
+ 
++	var buildBinds = []string{}
++	buildBindsJSON := r.FormValue("buildbinds")
++	if buildBindsJSON != "" {
++		if err := json.NewDecoder(strings.NewReader(buildBindsJSON)).Decode(&buildBinds); err != nil {
++			return errf(err)
++		}
++		buildConfig.Binds = buildBinds
++	}
++
+ 	remoteURL := r.FormValue("remote")
+ 
+ 	// Currently, only used if context is from a remote url.
+diff --git a/api/types/client.go b/api/types/client.go
+index 4846e50..c600b90 100644
+--- a/api/types/client.go
++++ b/api/types/client.go
+@@ -136,6 +136,7 @@ type ImageBuildOptions struct {
+ 	BuildArgs      []string
+ 	AuthConfigs    map[string]AuthConfig
+ 	Context        io.Reader
++	Binds          []string
+ }
+ 
+ // ImageBuildResponse holds information
+diff --git a/builder/dockerfile/builder.go b/builder/dockerfile/builder.go
+index 5b25444..1d0d90f 100644
+--- a/builder/dockerfile/builder.go
++++ b/builder/dockerfile/builder.go
+@@ -57,6 +57,7 @@ type Config struct {
+ 	// resource constraints
+ 	// TODO: factor out to be reused with Run ?
+ 
++	Binds        []string
+ 	Memory       int64
+ 	MemorySwap   int64
+ 	ShmSize      *int64
+diff --git a/builder/dockerfile/internals.go b/builder/dockerfile/internals.go
+index 0d87c12..7057077 100644
+--- a/builder/dockerfile/internals.go
++++ b/builder/dockerfile/internals.go
+@@ -37,6 +37,7 @@ import (
+ 	"github.com/docker/docker/pkg/tarsum"
+ 	"github.com/docker/docker/pkg/urlutil"
+ 	"github.com/docker/docker/runconfig"
++	volumePkg "github.com/docker/docker/volume"
+ )
+ 
+ func (b *Builder) commit(id string, autoCmd *stringutils.StrSlice, comment string) error {
+@@ -463,6 +464,9 @@ func (b *Builder) probeCache() (bool, error) {
+ 	if !ok || !b.UseCache || b.cacheBusted {
+ 		return false, nil
+ 	}
++	if len(b.Binds) > 0 {
++		return false, nil
++	}
+ 	cache, err := c.GetCachedImage(b.image, b.runConfig)
+ 	if err != nil {
+ 		return false, err
+@@ -498,11 +502,44 @@ func (b *Builder) create() (string, error) {
+ 		Ulimits:      b.Ulimits,
+ 	}
+ 
++	// ensure no rw flag is passed in bind-mounts.
++	// if it is just warn it's ignored
++	// and eventually build will fail itself trying to write to ro bind mounts
++	// also change everything to :ro
++	var warnings []string
++	for i, bind := range b.Binds {
++		arr := strings.Split(bind, ":")
++		switch len(arr) {
++		case 2:
++			b.Binds[i] = strings.Join([]string{arr[0], arr[1], "ro"}, ":")
++			break
++		case 3:
++			if volumePkg.ReadWrite(arr[2]) {
++				warnings = append(warnings, fmt.Sprintf("bind mount mode is read-write for %s, it will be changed to read-only", bind))
++				mode := "ro"
++				if strings.Contains(arr[2], "z") {
++					mode = mode + ",z"
++				} else if strings.Contains(arr[2], "Z") {
++					mode = mode + ",Z"
++				}
++				b.Binds[i] = strings.Join([]string{arr[0], arr[1], mode}, ":")
++			}
++			break
++		default:
++			// just skip, run will validate them all...
++		}
++	}
++
++	for _, warning := range warnings {
++		fmt.Fprintf(b.Stdout, " ---> [Warning] %s\n", warning)
++	}
++
+ 	// TODO: why not embed a hostconfig in builder?
+ 	hostConfig := &runconfig.HostConfig{
+ 		Isolation: b.Isolation,
+ 		ShmSize:   b.ShmSize,
+ 		Resources: resources,
++		Binds:     b.Binds,
+ 	}
+ 
+ 	config := *b.runConfig
+diff --git a/docs/reference/commandline/build.md b/docs/reference/commandline/build.md
+index 88e57dc..8f38641 100644
+--- a/docs/reference/commandline/build.md
++++ b/docs/reference/commandline/build.md
+@@ -35,6 +35,7 @@ parent = "smn_cli"
+       --shm-size=[]                   Size of `/dev/shm`. The format is `<number><unit>`. `number` must be greater than `0`.  Unit is optional and can be `b` (bytes), `k` (kilobytes), `m` (megabytes), or `g` (gigabytes). If you omit the unit, the system uses bytes. If you omit the size entirely, the system uses `64m`.
+       -t, --tag=[]                    Name and optionally a tag in the 'name:tag' format
+       --ulimit=[]                     Ulimit options
++      --v, --volume=[]                Set build-time bind mounts
+ 
+ Builds Docker images from a Dockerfile and a "context". A build's context is
+ the files located in the specified `PATH` or `URL`. The build process can refer
+diff --git a/integration-cli/docker_cli_build_test.go b/integration-cli/docker_cli_build_test.go
+index b540af5..88829e6 100644
+--- a/integration-cli/docker_cli_build_test.go
++++ b/integration-cli/docker_cli_build_test.go
+@@ -6623,3 +6623,141 @@ func (s *DockerSuite) TestBuildCacheRootSource(c *check.C) {
+ 
+ 	c.Assert(out, checker.Not(checker.Contains), "Using cache")
+ }
++
++func (s *DockerSuite) TestBuildWithBindMounts(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN cat /test/file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-v", tmpDir+":/test/", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.IsNil, check.Commentf(out))
++	c.Assert(out, checker.Contains, "foobar")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsFile(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN cat /file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-v", f+":/file", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.IsNil, check.Commentf(out))
++	c.Assert(out, checker.Contains, "foobar")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsNoVolume(c *check.C) {
++	dockerfile := `
++	FROM busybox
++	`
++	cmd := exec.Command(dockerBinary, "build", "-v", "/test", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.NotNil, check.Commentf(out))
++	c.Assert(out, checker.Contains, "Volumes aren't supported in docker build. Please use only bind mounts.")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsNotPersistedFile(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN cat /file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-v", f+":/file", "-t", "notpersisted", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.IsNil, check.Commentf(out))
++
++	out, _ = dockerCmd(c, "run", "notpersisted", "cat", "/file")
++	c.Assert(out, check.Not(checker.Contains), "foobar")
++	c.Assert(out, check.Equals, "")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsNotPersistedDir(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN cat /test/file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-t", "notpersisted", "-v", tmpDir+":/test/", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.IsNil, check.Commentf(out))
++
++	out, _, err = dockerCmdWithError("run", "notpersisted", "cat", "/test/file")
++	c.Assert(err, check.NotNil)
++	c.Assert(out, checker.Contains, "cat: can't open '/test/file': No such file or directory")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsReadOnlyDefault(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN echo "test" > /test/file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-t", "defaultro", "-v", tmpDir+":/test/", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.NotNil, check.Commentf(out))
++	c.Assert(out, checker.Contains, "Read-only file system")
++}
++
++func (s *DockerSuite) TestBuildWithBindMountsWarnOnReadWrite(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, SameHostDaemon)
++
++	dockerfile := `
++	FROM busybox
++	RUN cat /test/file
++	`
++	tmpDir, err := ioutil.TempDir("", "test")
++	c.Assert(err, check.IsNil)
++	f := filepath.Join(tmpDir, "file")
++	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
++
++	cmd := exec.Command(dockerBinary, "build", "-t", "defaultro", "-v", tmpDir+":/test/:rw,Z", "-")
++	cmd.Stdin = strings.NewReader(dockerfile)
++	out, _, err := runCommandWithOutput(cmd)
++	c.Assert(err, check.IsNil, check.Commentf(out))
++	c.Assert(out, checker.Contains, "it will be changed to read-only")
++	c.Assert(out, checker.Contains, "foobar")
++}
+diff --git a/man/docker-build.1.md b/man/docker-build.1.md
+index 4a87c4d..3722b0a 100644
+--- a/man/docker-build.1.md
++++ b/man/docker-build.1.md
+@@ -26,6 +26,7 @@ docker-build - Build a new image from the source code at PATH
+ [**--cpuset-cpus**[=*CPUSET-CPUS*]]
+ [**--cpuset-mems**[=*CPUSET-MEMS*]]
+ [**--ulimit**[=*[]*]]
++[**-v**|**--volume**[=*[]*]]
+ PATH | URL | -
+ 
+ # DESCRIPTION
+@@ -186,6 +187,12 @@ Cgroups are created if they do not already exist.
+ **--ulimit**=[]
+   Ulimit options
+ 
+++**-v**, **--volume**=[] Create a bind mount
+++   (format: `host-dir:container-dir[:<suffix options>]`, where suffix options
+++are comma delimited and selected from [ro] and [z|Z].). Read-write mode isn't supported at build time.
+++In case rw is specified a warning is printed during the build and it will be changed to ro preserving any SELinux mode provided.
+++
++
+   For more information about `ulimit` see [Setting ulimits in a 
+ container](https://docs.docker.com/reference/commandline/run/#setting-ulimits-in-a-container)
+ 
+-- 
+2.5.0
+

--- a/patch/0011-Add-add-registry-and-block-registry-options-to-docke.patch
+++ b/patch/0011-Add-add-registry-and-block-registry-options-to-docke.patch
@@ -1,0 +1,2808 @@
+From 1c1c8469bdb51d8b3599139e24c19129ae565c87 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Wed, 16 Dec 2015 13:29:44 -0500
+Subject: [PATCH 11/13] Add --add-registry and --block-registry options to
+ docker daemon
+
+The first option allows to prepend additional registries to a public
+one. These will be queried one after another - in the same order they
+were given - when pulling images.
+
+For example:
+
+    --add-registry=foo.com
+    --add-registry=bar.com
+
+Would cause a
+
+    docker pull myapp
+
+to search
+
+    foo.com/myapp
+    bar.com/myapp
+    docker.io/myapp
+
+The second option builds a list of banned registries. Docker daemon will
+prevent user from any communication with such registries. This option
+recognizes a special keyword "public" denoting public Docker registry.
+
+So for example adding `--block-registry=public` to daemon flags of
+previous example would result in searching the same registries except
+for `docker.io/myapp`.
+
+Both flags are marked as experimental in man pages.
+
+This would allow companies and vendors to specify registries which
+contain content that the companies will not allowed to be stored at
+docker.io.
+
+The same applies to `FROM` statement in Dockerfile when issuing a build.
+
+This patch also causes all pulled repositories to be fully qualified -
+including those coming from the public registry.
+
+Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
+Signed-off-by: Michal Minar <miminar@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/client/login.go                           |   4 +-
+ api/client/logout.go                          |   4 +-
+ api/server/router/local/image.go              |   4 +-
+ contrib/completion/bash/docker                |   2 +
+ contrib/completion/fish/docker.fish           |   2 +
+ daemon/commit.go                              |   2 +-
+ daemon/config.go                              |  43 ++---
+ daemon/daemon.go                              |   5 +-
+ daemon/images.go                              |  69 +++++---
+ daemon/import.go                              |   2 +-
+ daemon/info.go                                |   2 +-
+ distribution/pull.go                          |  39 ++++-
+ distribution/push.go                          |  16 +-
+ docker/daemon.go                              |  20 +++
+ docker/docker.go                              |   6 +
+ image/tarexport/save.go                       |  12 +-
+ integration-cli/check_test.go                 |  48 +++++-
+ integration-cli/docker_cli_build_test.go      | 185 +++++++++++++++++++++
+ integration-cli/docker_cli_images_test.go     |  55 +++++++
+ integration-cli/docker_cli_pull_local_test.go | 144 +++++++++++++++++
+ integration-cli/docker_cli_pull_test.go       | 220 ++++++++++++++++++++++++-
+ integration-cli/docker_cli_push_test.go       | 107 +++++++++++++
+ integration-cli/docker_cli_rmi_test.go        |  25 ++-
+ integration-cli/docker_cli_run_test.go        |  70 ++++++++
+ integration-cli/docker_cli_tag_test.go        |   2 +-
+ integration-cli/docker_test_vars.go           |   3 +-
+ integration-cli/docker_utils.go               | 155 ++++++++++++++++--
+ integration-cli/registry.go                   |  12 +-
+ man/docker-daemon.8.md                        |   8 +
+ registry/config.go                            | 221 +++++++++++++++++++++++---
+ registry/registry_mock_test.go                |   6 +-
+ registry/registry_test.go                     |  20 +--
+ registry/service.go                           |  25 +--
+ registry/session.go                           |  57 +++++--
+ tag/store.go                                  | 123 ++++++++++----
+ 35 files changed, 1544 insertions(+), 174 deletions(-)
+
+diff --git a/api/client/login.go b/api/client/login.go
+index 3b7a547..5eb00f4 100644
+--- a/api/client/login.go
++++ b/api/client/login.go
+@@ -22,7 +22,7 @@ import (
+ //
+ // Usage: docker login SERVER
+ func (cli *DockerCli) CmdLogin(args ...string) error {
+-	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified \""+registry.IndexServer+"\" is the default.", true)
++	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified \""+registry.IndexServerName()+"\" is the default.", true)
+ 	cmd.Require(flag.Max, 1)
+ 
+ 	var username, password, email string
+@@ -38,7 +38,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
+ 		cli.in = os.Stdin
+ 	}
+ 
+-	serverAddress := registry.IndexServer
++	serverAddress := registry.IndexServerName()
+ 	if len(cmd.Args()) > 0 {
+ 		serverAddress = cmd.Arg(0)
+ 	}
+diff --git a/api/client/logout.go b/api/client/logout.go
+index 3753cbb..120635f 100644
+--- a/api/client/logout.go
++++ b/api/client/logout.go
+@@ -14,12 +14,12 @@ import (
+ //
+ // Usage: docker logout [SERVER]
+ func (cli *DockerCli) CmdLogout(args ...string) error {
+-	cmd := Cli.Subcmd("logout", []string{"[SERVER]"}, Cli.DockerCommands["logout"].Description+".\nIf no server is specified \""+registry.IndexServer+"\" is the default.", true)
++	cmd := Cli.Subcmd("logout", []string{"[SERVER]"}, Cli.DockerCommands["logout"].Description+".\nIf no server is specified \""+registry.IndexServerName()+"\" is the default.", true)
+ 	cmd.Require(flag.Max, 1)
+ 
+ 	cmd.ParseFlags(args, true)
+ 
+-	serverAddress := registry.IndexServer
++	serverAddress := registry.IndexServerName()
+ 	if len(cmd.Args()) > 0 {
+ 		serverAddress = cmd.Arg(0)
+ 	}
+diff --git a/api/server/router/local/image.go b/api/server/router/local/image.go
+index 25f315a..32e0da9 100644
+--- a/api/server/router/local/image.go
++++ b/api/server/router/local/image.go
+@@ -480,7 +480,7 @@ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
+ 	}
+ 
+ 	for _, rt := range repoAndTags {
+-		if err := s.daemon.TagImage(rt, imgID); err != nil {
++		if err := s.daemon.TagImage(rt, imgID, true); err != nil {
+ 			return errf(err)
+ 		}
+ 	}
+@@ -564,7 +564,7 @@ func (s *router) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
+ 			return err
+ 		}
+ 	}
+-	if err := s.daemon.TagImage(newTag, vars["name"]); err != nil {
++	if err := s.daemon.TagImage(newTag, vars["name"], true); err != nil {
+ 		return err
+ 	}
+ 	w.WriteHeader(http.StatusCreated)
+diff --git a/contrib/completion/bash/docker b/contrib/completion/bash/docker
+index 4a1b2f3..e2d804b 100644
+--- a/contrib/completion/bash/docker
++++ b/contrib/completion/bash/docker
+@@ -655,9 +655,11 @@ _docker_daemon() {
+ 	"
+ 	local options_with_args="
+ 		$global_options_with_args
++		--add-registry
+ 		--api-cors-header
+ 		--authz-plugin
+ 		--bip
++		--block-registry
+ 		--bridge -b
+ 		--cluster-advertise
+ 		--cluster-store
+diff --git a/contrib/completion/fish/docker.fish b/contrib/completion/fish/docker.fish
+index 33abfd0..7f8db76 100644
+--- a/contrib/completion/fish/docker.fish
++++ b/contrib/completion/fish/docker.fish
+@@ -43,9 +43,11 @@ function __fish_print_docker_repositories --description 'Print a list of docker
+ end
+ 
+ # common options
++complete -c docker -f -n '__fish_docker_no_subcommand' -l add-registry -d 'Query given registry before a public one'
+ complete -c docker -f -n '__fish_docker_no_subcommand' -l api-cors-header -d "Set CORS headers in the remote API. Default is cors disabled"
+ complete -c docker -f -n '__fish_docker_no_subcommand' -s b -l bridge -d 'Attach containers to a pre-existing network bridge'
+ complete -c docker -f -n '__fish_docker_no_subcommand' -l bip -d "Use this CIDR notation address for the network bridge's IP, not compatible with -b"
++complete -c docker -f -n '__fish_docker_no_subcommand' -l block-registry -d "Don't contact given registry"
+ complete -c docker -f -n '__fish_docker_no_subcommand' -s D -l debug -d 'Enable debug mode'
+ complete -c docker -f -n '__fish_docker_no_subcommand' -s d -l daemon -d 'Enable daemon mode'
+ complete -c docker -f -n '__fish_docker_no_subcommand' -l dns -d 'Force Docker to use specific DNS servers'
+diff --git a/daemon/commit.go b/daemon/commit.go
+index 1d3d738..cd0bdb9 100644
+--- a/daemon/commit.go
++++ b/daemon/commit.go
+@@ -125,7 +125,7 @@ func (daemon *Daemon) Commit(name string, c *types.ContainerCommitConfig) (strin
+ 				return "", err
+ 			}
+ 		}
+-		if err := daemon.TagImage(newTag, id.String()); err != nil {
++		if err := daemon.TagImage(newTag, id.String(), true); err != nil {
+ 			return "", err
+ 		}
+ 	}
+diff --git a/daemon/config.go b/daemon/config.go
+index a842bda..1c129be 100644
+--- a/daemon/config.go
++++ b/daemon/config.go
+@@ -3,6 +3,7 @@ package daemon
+ import (
+ 	"github.com/docker/docker/opts"
+ 	flag "github.com/docker/docker/pkg/mflag"
++	"github.com/docker/docker/registry"
+ 	"github.com/docker/docker/runconfig"
+ )
+ 
+@@ -14,25 +15,27 @@ const (
+ // CommonConfig defines the configuration of a docker daemon which are
+ // common across platforms.
+ type CommonConfig struct {
+-	AuthZPlugins  []string // AuthZPlugins holds list of authorization plugins
+-	AutoRestart   bool
+-	Bridge        bridgeConfig // Bridge holds bridge network specific configuration.
+-	Context       map[string][]string
+-	DisableBridge bool
+-	DNS           []string
+-	DNSOptions    []string
+-	DNSSearch     []string
+-	ExecOptions   []string
+-	ExecRoot      string
+-	GraphDriver   string
+-	GraphOptions  []string
+-	Labels        []string
+-	LogConfig     runconfig.LogConfig
+-	Mtu           int
+-	Pidfile       string
+-	RemappedRoot  string
+-	Root          string
+-	TrustKeyPath  string
++	AuthZPlugins         []string // AuthZPlugins holds list of authorization plugins
++	AutoRestart          bool
++	Bridge               bridgeConfig // Bridge holds bridge network specific configuration.
++	Context              map[string][]string
++	DisableBridge        bool
++	DNS                  []string
++	DNSOptions           []string
++	DNSSearch            []string
++	ExecOptions          []string
++	ExecRoot             string
++	GraphDriver          string
++	GraphOptions         []string
++	Labels               []string
++	LogConfig            runconfig.LogConfig
++	Mtu                  int
++	Pidfile              string
++	RemappedRoot         string
++	Root                 string
++	TrustKeyPath         string
++	BlockedRegistries    []string
++	AdditionalRegistries []string
+ 
+ 	// ClusterStore is the storage backend used for the cluster information. It is used by both
+ 	// multihost networking (to store networks and endpoints information) and by the node discovery
+@@ -73,4 +76,6 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
+ 	cmd.StringVar(&config.ClusterAdvertise, []string{"-cluster-advertise"}, "", usageFn("Address or interface name to advertise"))
+ 	cmd.StringVar(&config.ClusterStore, []string{"-cluster-store"}, "", usageFn("Set the cluster store"))
+ 	cmd.Var(opts.NewMapOpts(config.ClusterOpts, nil), []string{"-cluster-store-opt"}, usageFn("Set cluster store options"))
++	cmd.Var(opts.NewListOptsRef(&config.BlockedRegistries, registry.ValidateIndexName), []string{"-block-registry"}, usageFn("Don't contact given registry"))
++	cmd.Var(opts.NewListOptsRef(&config.AdditionalRegistries, registry.ValidateIndexName), []string{"-add-registry"}, usageFn("Registry to query before a public one"))
+ }
+diff --git a/daemon/daemon.go b/daemon/daemon.go
+index 2e38e68..ce2fa73 100644
+--- a/daemon/daemon.go
++++ b/daemon/daemon.go
+@@ -1039,12 +1039,12 @@ func (daemon *Daemon) changes(container *container.Container) ([]archive.Change,
+ 
+ // TagImage creates a tag in the repository reponame, pointing to the image named
+ // imageName.
+-func (daemon *Daemon) TagImage(newTag reference.Named, imageName string) error {
++func (daemon *Daemon) TagImage(newTag reference.Named, imageName string, keepUnqualified bool) error {
+ 	imageID, err := daemon.GetImageID(imageName)
+ 	if err != nil {
+ 		return err
+ 	}
+-	newTag = registry.NormalizeLocalReference(newTag)
++	newTag = registry.NormalizeLocalReference(newTag, keepUnqualified)
+ 	if err := daemon.tagStore.AddTag(newTag, imageID, true); err != nil {
+ 		return err
+ 	}
+@@ -1302,7 +1302,6 @@ func (daemon *Daemon) GetImageID(refOrID string) (image.ID, error) {
+ 
+ 	// Treat it as a possible tag or digest reference
+ 	if ref, err := reference.ParseNamed(refOrID); err == nil {
+-		ref = registry.NormalizeLocalReference(ref)
+ 		if id, err := daemon.tagStore.Get(ref); err == nil {
+ 			return id, nil
+ 		}
+diff --git a/daemon/images.go b/daemon/images.go
+index 9220400..f3872ae 100644
+--- a/daemon/images.go
++++ b/daemon/images.go
+@@ -10,6 +10,7 @@ import (
+ 	"github.com/docker/docker/api/types/filters"
+ 	"github.com/docker/docker/image"
+ 	"github.com/docker/docker/layer"
++	"github.com/docker/docker/registry"
+ )
+ 
+ var acceptedImageFilterTags = map[string]bool{
+@@ -30,6 +31,53 @@ func (daemon *Daemon) Map() map[image.ID]*image.Image {
+ 	return daemon.imageStore.Map()
+ }
+ 
++func matchReference(filter string, ref reference.Named) bool {
++	if filter == "" {
++		return true
++	}
++
++	var filterTagged bool
++	filterRef, err := reference.Parse(filter)
++	if err == nil { // parse error means wildcard repo
++		if _, ok := filterRef.(reference.Tagged); ok {
++			filterTagged = true
++		}
++	}
++
++	refBelongsToDefaultRegistry := false
++	indexName, remoteNameStr := reference.SplitHostname(ref)
++	for _, reg := range registry.RegistryList {
++		if indexName == reg || indexName == "" {
++			refBelongsToDefaultRegistry = true
++			break
++		}
++	}
++
++	// If the repository belongs to default registry, match against fully
++	// qualified and unqualified name.
++	references := []reference.Named{ref}
++	if registry.IsReferenceFullyQualified(ref) && refBelongsToDefaultRegistry {
++		newRef, err := registry.SubstituteReferenceName(ref, remoteNameStr)
++		if err == nil {
++			references = append(references, newRef)
++		}
++	}
++
++	for _, ref := range references {
++		if filterTagged {
++			// filter by tag, require full ref match
++			if ref.String() == filter {
++				return true
++			}
++		} else if matched, err := path.Match(filter, ref.Name()); matched && err == nil {
++			// name only match, FIXME: docs say exact
++			return true
++		}
++	}
++
++	return false
++}
++
+ // Images returns a filtered list of images. filterArgs is a JSON-encoded set
+ // of filter arguments which will be interpreted by api/types/filters.
+ // filter is a shell glob string applied to repository names. The argument
+@@ -66,16 +114,6 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
+ 
+ 	images := []*types.Image{}
+ 
+-	var filterTagged bool
+-	if filter != "" {
+-		filterRef, err := reference.Parse(filter)
+-		if err == nil { // parse error means wildcard repo
+-			if _, ok := filterRef.(reference.Tagged); ok {
+-				filterTagged = true
+-			}
+-		}
+-	}
+-
+ 	for id, img := range allImages {
+ 		if imageFilters.Include("label") {
+ 			// Very old image that do not have image.Config (or even labels)
+@@ -106,15 +144,10 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
+ 		newImage := newImage(img, size)
+ 
+ 		for _, ref := range daemon.tagStore.References(id) {
+-			if filter != "" { // filter by tag/repo name
+-				if filterTagged { // filter by tag, require full ref match
+-					if ref.String() != filter {
+-						continue
+-					}
+-				} else if matched, err := path.Match(filter, ref.Name()); !matched || err != nil { // name only match, FIXME: docs say exact
+-					continue
+-				}
++			if !matchReference(filter, ref) {
++				continue
+ 			}
++
+ 			if _, ok := ref.(reference.Digested); ok {
+ 				newImage.RepoDigests = append(newImage.RepoDigests, ref.String())
+ 			}
+diff --git a/daemon/import.go b/daemon/import.go
+index 75010e3..9a5dc1f 100644
+--- a/daemon/import.go
++++ b/daemon/import.go
+@@ -92,7 +92,7 @@ func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string
+ 
+ 	// FIXME: connect with commit code and call tagstore directly
+ 	if newRef != nil {
+-		if err := daemon.TagImage(newRef, id.String()); err != nil {
++		if err := daemon.TagImage(newRef, id.String(), true); err != nil {
+ 			return err
+ 		}
+ 	}
+diff --git a/daemon/info.go b/daemon/info.go
+index 804bbeb..d8efaf6 100644
+--- a/daemon/info.go
++++ b/daemon/info.go
+@@ -75,7 +75,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 		NEventsListener:    daemon.EventsService.SubscribersCount(),
+ 		KernelVersion:      kernelVersion,
+ 		OperatingSystem:    operatingSystem,
+-		IndexServerAddress: registry.IndexServer,
++		IndexServerAddress: registry.IndexServerAddress(),
+ 		OSType:             platform.OSType,
+ 		Architecture:       platform.Architecture,
+ 		RegistryConfig:     daemon.RegistryService.Config,
+diff --git a/distribution/pull.go b/distribution/pull.go
+index 9180de5..8bbc0e2 100644
+--- a/distribution/pull.go
++++ b/distribution/pull.go
+@@ -78,9 +78,40 @@ func newPuller(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo,
+ 	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
+ }
+ 
+-// Pull initiates a pull operation. image is the repository name to pull, and
+-// tag may be either empty, or indicate a specific tag to pull.
++// Pull initiates a pull operation for given reference. If the reference is
++// fully qualified, image will be pulled from given registry. Otherwise
++// additional registries will be queried until the reference is found.
+ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullConfig) error {
++	// Unless the index name is specified, iterate over all registries until
++	// the matching image is found.
++	if registry.IsReferenceFullyQualified(ref) {
++		return pullFromRegistry(ctx, ref, imagePullConfig)
++	}
++	if len(registry.RegistryList) == 0 {
++		return fmt.Errorf("No configured registry to pull from.")
++	}
++	err := registry.ValidateRepositoryName(ref)
++	if err != nil {
++		return err
++	}
++	for _, r := range registry.RegistryList {
++		// Prepend the index name to the image name.
++		fqr, _err := registry.FullyQualifyReferenceWith(r, ref)
++		if _err != nil {
++			logrus.Warnf("Failed to fully qualify %q name with %q registry: %v", ref.Name(), r, _err)
++			err = _err
++			continue
++		}
++		if err = pullFromRegistry(ctx, fqr, imagePullConfig); err == nil {
++			return nil
++		}
++	}
++	return err
++}
++
++// pullFromRegistry initiates a pull operation from particular registry. ref is
++// a fully qualified image reference.
++func pullFromRegistry(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullConfig) error {
+ 	// Resolve the Repository name from fqn to RepositoryInfo
+ 	repoInfo, err := imagePullConfig.RegistryService.ResolveRepository(ref)
+ 	if err != nil {
+@@ -97,7 +128,7 @@ func Pull(ctx context.Context, ref reference.Named, imagePullConfig *ImagePullCo
+ 		return err
+ 	}
+ 
+-	localName := registry.NormalizeLocalReference(ref)
++	localName := registry.NormalizeLocalReference(ref, false)
+ 
+ 	var (
+ 		// use a slice to append the error strings and return a joined string to caller
+@@ -180,7 +211,7 @@ func validateRepoName(name string) error {
+ 	if name == "" {
+ 		return fmt.Errorf("Repository name can't be empty")
+ 	}
+-	if name == "scratch" {
++	if strings.TrimPrefix(name, registry.IndexName+"/") == "scratch" {
+ 		return fmt.Errorf("'scratch' is a reserved name")
+ 	}
+ 	return nil
+diff --git a/distribution/push.go b/distribution/push.go
+index c9aef91..06844a2 100644
+--- a/distribution/push.go
++++ b/distribution/push.go
+@@ -5,6 +5,7 @@ import (
+ 	"compress/gzip"
+ 	"fmt"
+ 	"io"
++	"strings"
+ 
+ 	"github.com/Sirupsen/logrus"
+ 	"github.com/docker/distribution/digest"
+@@ -105,6 +106,19 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
+ 		return err
+ 	}
+ 
++	// If we're not using a custom registry, we know the restrictions
++	// applied to repository names and can warn the user in advance.
++	// Custom repositories can have different rules, and we must also
++	// allow pushing by image ID.
++	if repoInfo.Official {
++		username := imagePushConfig.AuthConfig.Username
++		if username == "" {
++			username = "<user>"
++		}
++		name := strings.TrimPrefix(repoInfo.RemoteName.Name(), registry.OfficialReposNamePrefix)
++		return fmt.Errorf("You cannot push a \"root\" repository. Please rename your repository to %s/<user>/<repo> (ex: %s/%s/%s)", registry.IndexName, registry.IndexName, username, name)
++	}
++
+ 	endpoints, err := imagePushConfig.RegistryService.LookupPushEndpoints(repoInfo.CanonicalName)
+ 	if err != nil {
+ 		return err
+@@ -112,7 +126,7 @@ func Push(ctx context.Context, ref reference.Named, imagePushConfig *ImagePushCo
+ 
+ 	progress.Messagef(imagePushConfig.ProgressOutput, "", "The push refers to a repository [%s]", repoInfo.CanonicalName.String())
+ 
+-	associations := imagePushConfig.TagStore.ReferencesByName(repoInfo.LocalName)
++	associations := imagePushConfig.TagStore.ReferencesByName(ref)
+ 	if len(associations) == 0 {
+ 		return fmt.Errorf("Repository does not exist: %s", repoInfo.LocalName)
+ 	}
+diff --git a/docker/daemon.go b/docker/daemon.go
+index 5410aa2..a8bbdbc 100644
+--- a/docker/daemon.go
++++ b/docker/daemon.go
+@@ -176,6 +176,26 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
+ 		}()
+ 	}
+ 
++	for _, r := range cli.BlockedRegistries {
++		if r == "all" {
++			r = "*"
++		} else if r == "public" {
++			r = registry.IndexName
++		}
++		registry.BlockedRegistries[r] = struct{}{}
++		if r == registry.IndexName || r == "*" {
++			registry.RegistryList = []string{}
++		}
++	}
++
++	newRegistryList := []string{}
++	for _, r := range cli.AdditionalRegistries {
++		if _, ok := registry.BlockedRegistries[r]; !ok {
++			newRegistryList = append(newRegistryList, r)
++		}
++	}
++	registry.RegistryList = append(newRegistryList, registry.RegistryList...)
++
+ 	serverConfig := &apiserver.Config{
+ 		AuthZPluginNames: cli.Config.AuthZPlugins,
+ 		Logging:          true,
+diff --git a/docker/docker.go b/docker/docker.go
+index 9c4180c..cf868bc 100644
+--- a/docker/docker.go
++++ b/docker/docker.go
+@@ -59,6 +59,12 @@ func main() {
+ 
+ 	clientCli := client.NewDockerCli(stdin, stdout, stderr, clientFlags)
+ 
++	for _, lopt := range []string{"-add-registry", "-block-registry"} {
++		if flag.IsSet(lopt) {
++			logrus.Fatalf("The -%s option is recognized only by Docker daemon.", lopt)
++		}
++	}
++
+ 	c := cli.New(clientCli, daemonCli)
+ 	if err := c.Run(flag.Args()...); err != nil {
+ 		if sterr, ok := err.(cli.StatusError); ok {
+diff --git a/image/tarexport/save.go b/image/tarexport/save.go
+index f16a149..0c3f4c9 100644
+--- a/image/tarexport/save.go
++++ b/image/tarexport/save.go
+@@ -75,8 +75,8 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-		ref = registry.NormalizeLocalReference(ref)
+-		if ref.Name() == string(digest.Canonical) {
++		normalized := registry.NormalizeLocalReference(ref, true)
++		if normalized.Name() == string(digest.Canonical) {
+ 			imgID, err := l.is.Search(name)
+ 			if err != nil {
+ 				return nil, err
+@@ -84,8 +84,8 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
+ 			addAssoc(imgID, nil)
+ 			continue
+ 		}
+-		if _, ok := ref.(reference.Digested); !ok {
+-			if _, ok := ref.(reference.NamedTagged); !ok {
++		if _, ok := normalized.(reference.Digested); !ok {
++			if _, ok := normalized.(reference.NamedTagged); !ok {
+ 				assocs := l.ts.ReferencesByName(ref)
+ 				for _, assoc := range assocs {
+ 					addAssoc(assoc.ImageID, assoc.Ref)
+@@ -101,10 +101,10 @@ func (l *tarexporter) parseNames(names []string) (map[image.ID]*imageDescriptor,
+ 			}
+ 		}
+ 		var imgID image.ID
+-		if imgID, err = l.ts.Get(ref); err != nil {
++		if imgID, err = l.ts.Get(normalized); err != nil {
+ 			return nil, err
+ 		}
+-		addAssoc(imgID, ref)
++		addAssoc(imgID, normalized)
+ 
+ 	}
+ 	return imgDescr, nil
+diff --git a/integration-cli/check_test.go b/integration-cli/check_test.go
+index 030b07f..7e996dd 100644
+--- a/integration-cli/check_test.go
++++ b/integration-cli/check_test.go
+@@ -59,7 +59,9 @@ func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
+ 	if s.ds != nil {
+ 		s.ds.TearDownTest(c)
+ 	}
+-	s.d.Stop()
++	if s.d != nil {
++		s.d.Stop()
++	}
+ }
+ 
+ func init() {
+@@ -80,7 +82,9 @@ func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
+ 
+ func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
+ 	testRequires(c, DaemonIsLinux)
+-	s.d.Stop()
++	if s.d != nil {
++		s.d.Stop()
++	}
+ 	s.ds.TearDownTest(c)
+ }
+ 
+@@ -102,7 +106,43 @@ func (s *DockerTrustSuite) SetUpTest(c *check.C) {
+ }
+ 
+ func (s *DockerTrustSuite) TearDownTest(c *check.C) {
+-	s.reg.Close()
+-	s.not.Close()
++	if s.reg != nil {
++		s.reg.Close()
++	}
++	if s.not != nil {
++		s.not.Close()
++	}
++	s.ds.TearDownTest(c)
++}
++
++type DockerRegistriesSuite struct {
++	ds   *DockerSuite
++	reg1 *testRegistryV2
++	reg2 *testRegistryV2
++	d    *Daemon
++}
++
++func (s *DockerRegistriesSuite) SetUpTest(c *check.C) {
++	s.reg1 = setupRegistryAt(c, privateRegistryURL)
++	s.reg2 = setupRegistryAt(c, privateRegistryURL2)
++	s.d = NewDaemon(c)
++}
++
++func (s *DockerRegistriesSuite) TearDownTest(c *check.C) {
++	if s.reg2 != nil {
++		s.reg2.Close()
++	}
++	if s.reg1 != nil {
++		s.reg1.Close()
++	}
++	if s.d != nil {
++		s.d.Stop()
++	}
+ 	s.ds.TearDownTest(c)
+ }
++
++func init() {
++	check.Suite(&DockerRegistriesSuite{
++		ds: &DockerSuite{},
++	})
++}
+diff --git a/integration-cli/docker_cli_build_test.go b/integration-cli/docker_cli_build_test.go
+index 88829e6..625b45c 100644
+--- a/integration-cli/docker_cli_build_test.go
++++ b/integration-cli/docker_cli_build_test.go
+@@ -6761,3 +6761,188 @@ func (s *DockerSuite) TestBuildWithBindMountsWarnOnReadWrite(c *check.C) {
+ 	c.Assert(out, checker.Contains, "it will be changed to read-only")
+ 	c.Assert(out, checker.Contains, "foobar")
+ }
++
++func (s *DockerRegistrySuite) TestBuildWithAdditionalRegistry(c *check.C) {
++	name := "testbuildwithadditionalregistry"
++	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
++	}
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// build image based on hello-world from docker.io
++	_, _, err := s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM library/hello-world
++  ENV test %s
++  `, name), true)
++	if err != nil {
++		c.Fatal(err)
++	}
++	hwImg := s.d.getAndTestImageEntry(c, 3, "docker.io/hello-world", "")
++	if hwImg.id == bbImg.id {
++		c.Fatalf("docker.io/hello-world must have different ID than busybox image")
++	}
++	bImg := s.d.getAndTestImageEntry(c, 3, name, "")
++	if bImg.id == hwImg.id || bImg.id == bbImg.id {
++		c.Fatalf("built image %s must have different ID than other images", name)
++	}
++	res, err := s.d.inspectField(name, "Parent")
++	if err != nil {
++		c.Fatal(err)
++	}
++	if !strings.HasPrefix(res, hwImg.id) {
++		c.Fatalf("built image %s should have docker.io/hello-world(id=%s) as a parent, not %s", name, hwImg.id, res)
++	}
++
++	// push busybox to additional registry as "library/hello-world"
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/hello-world", err, out)
++	}
++	toRemove := []string{s.reg.url + "/library/hello-world", "hello-world"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 2, name, "")
++
++	// Build again. The result shall now be based on busybox image from
++	// additional registry.
++	_, _, err = s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM library/hello-world
++  ENV test %s
++  `, name), true)
++	if err != nil {
++		c.Fatal(err)
++	}
++	s.d.getAndTestImageEntry(c, 4, s.reg.url+"/library/hello-world", bbImg.id)
++	s.d.getAndTestImageEntry(c, 4, name, "")
++	res, err = s.d.inspectField(name, "Parent")
++	if err != nil {
++		c.Fatal(err)
++	}
++	if !strings.HasPrefix(res, bbImg.id) {
++		c.Fatalf("built image %s should have busybox image (id=%s) as a parent, not %s", name, bbImg.id, res)
++	}
++
++	// build again with docker.io explicitly specified
++	_, _, err = s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM docker.io/library/hello-world
++  ENV test %s
++  `, name), true)
++	if err != nil {
++		c.Fatal(err)
++	}
++	s.d.getAndTestImageEntry(c, 5, "docker.io/hello-world", hwImg.id)
++	s.d.getAndTestImageEntry(c, 5, name, "")
++	res, err = s.d.inspectField(name, "Parent")
++	if err != nil {
++		c.Fatal(err)
++	}
++	if !strings.HasPrefix(res, hwImg.id) {
++		c.Fatalf("built image %s should have docker.io/hello-world(id=%s) as a parent, not %s", name, hwImg.id, res)
++	}
++
++	// build again from additional registry explicitly specified
++	_, _, err = s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM %s/library/hello-world
++  ENV test %s
++  `, s.reg.url, name), true)
++	if err != nil {
++		c.Fatal(err)
++	}
++	s.d.getAndTestImageEntry(c, 5, s.reg.url+"/library/hello-world", bbImg.id)
++	res, err = s.d.inspectField(name, "Parent")
++	if err != nil {
++		c.Fatal(err)
++	}
++	if !strings.HasPrefix(res, bbImg.id) {
++		c.Fatalf("built image %s should have busybox(id=%s) as a parent, not %s", name, bbImg.id, res)
++	}
++}
++
++// Test building of image based on busybox with public registry blocked. Name
++// of image that shall be built is specified by `name`. Parameter `daemonArgs`
++// shall contain at least one `--block-registry` flag.
++func (s *DockerRegistrySuite) doTestBuildWithPublicRegistryBlocked(c *check.C, name string, daemonArgs []string) {
++	allBlocked := false
++	for _, arg := range daemonArgs {
++		if arg == "--block-registry=all" {
++			allBlocked = true
++		}
++	}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s }: %v", strings.Join(daemonArgs, ", "), err)
++	}
++	busyboxID := s.d.getAndTestImageEntry(c, 1, "busybox", "").id
++
++	// try to build image based on hello-world from docker.io
++	_, _, err := s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM library/hello-world
++  ENV test %s
++  `, name), true)
++	if err == nil {
++		c.Fatal("build should have failed because of public registry being blocked")
++	}
++
++	// now base the image on local busybox image
++	_, _, err = s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM busybox
++  ENV test %s
++  `, name), true)
++	if err != nil {
++		c.Fatal(err)
++	}
++	s.d.getAndTestImageEntry(c, 2, name, "")
++	if res, err := s.d.inspectField(name, "Parent"); err != nil {
++		c.Fatal(err)
++	} else if !strings.HasPrefix(res, busyboxID) {
++		c.Fatalf("built image %s should have busybox(id=%s) as a parent, not %s", name, busyboxID, res)
++	}
++
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/library/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg.url+"/library/busybox"); !allBlocked && err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/busybox", err, out)
++	} else if allBlocked && err == nil {
++		c.Fatalf("push to private registry should have failed, output: %q", out)
++	}
++
++	toRemove := []string{"busybox", s.reg.url + "/library/busybox"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 1, name, "")
++
++	// now base the image on busybox from private registry
++	_, _, err = s.d.buildImageWithOut(name, fmt.Sprintf(`
++  FROM %s/library/busybox
++  ENV test %s
++  `, s.reg.url, name), true)
++	if !allBlocked && err != nil {
++		c.Fatal(err)
++	} else if allBlocked && err == nil {
++		c.Fatalf("the build should have failed due to all registries being blocked")
++	}
++	if !allBlocked {
++		s.d.getAndTestImageEntry(c, 2, name, "")
++		if res, err := s.d.inspectField(name, "Parent"); err != nil {
++			c.Fatal(err)
++		} else if !strings.HasPrefix(res, busyboxID) {
++			c.Fatalf("built image %s should have busybox image (id=%s) as a parent, not %s", name, busyboxID, res)
++		}
++	}
++}
++
++func (s *DockerRegistrySuite) TestBuildWithPublicRegistryBlocked(c *check.C) {
++	for _, blockedRegistry := range []string{"public", "docker.io"} {
++		s.doTestBuildWithPublicRegistryBlocked(c, "testbuildpublicregistryblocked", []string{"--block-registry=" + blockedRegistry})
++		s.d.Stop()
++		s.d = NewDaemon(c)
++	}
++}
++
++func (s *DockerRegistrySuite) TestBuildWithAllRegistriesBlocked(c *check.C) {
++	s.doTestBuildWithPublicRegistryBlocked(c, "testbuildwithallregistriesblocked", []string{"--block-registry=all"})
++}
+diff --git a/integration-cli/docker_cli_images_test.go b/integration-cli/docker_cli_images_test.go
+index d821150..bc7aad8 100644
+--- a/integration-cli/docker_cli_images_test.go
++++ b/integration-cli/docker_cli_images_test.go
+@@ -233,3 +233,58 @@ func (s *DockerSuite) TestImagesFilterNameWithPort(c *check.C) {
+ 	out, _ = dockerCmd(c, "images", tag+":no-such-tag")
+ 	c.Assert(out, checker.Not(checker.Contains), tag)
+ }
++
++func (s *DockerDaemonSuite) doTestImagesWithAdditionalRegistry(c *check.C, publicBlocked bool) {
++	daemonArgs := []string{"--add-registry=example.com"}
++	if publicBlocked {
++		daemonArgs = append(daemonArgs, "--block-registry=public")
++	}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	if out, err := s.d.Cmd("tag", "busybox", "example.com/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", "docker.io/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", "other.com/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++
++	expected := []string{"busybox:latest", "example.com/busybox:latest"}
++	if !publicBlocked {
++		expected = append(expected, "docker.io/busybox:latest")
++	}
++	images := s.d.getImages(c, "*box")
++	if len(images) != len(expected) {
++		c.Errorf("got     : %v", images)
++		c.Errorf("expected: %v", expected)
++		c.Fatalf("got unexpected number of images (%d), expected: %d, images: %v", len(images), len(expected), images)
++	}
++	for _, exp := range expected {
++		if _, ok := images[exp]; !ok {
++			c.Errorf("expected image name %s, not found among images: %v", exp, images)
++		}
++	}
++
++	expected = []string{"docker.io/busybox:latest", "example.com/busybox:latest", "other.com/busybox:latest"}
++	images = s.d.getImages(c, "*/*box")
++	if len(images) != len(expected) {
++		c.Fatalf("got unexpected number of images (%d), expected: %d, images: %v", len(images), len(expected), images)
++	}
++	for _, exp := range expected {
++		if _, ok := images[exp]; !ok {
++			c.Errorf("expected image name %s, not found among images: %v", exp, images)
++		}
++	}
++}
++
++func (s *DockerDaemonSuite) TestImagesWithAdditionalRegistry(c *check.C) {
++	s.doTestImagesWithAdditionalRegistry(c, false)
++}
++
++func (s *DockerDaemonSuite) TestImagesWithPublicRegistryBlocked(c *check.C) {
++	s.doTestImagesWithAdditionalRegistry(c, true)
++}
+diff --git a/integration-cli/docker_cli_pull_local_test.go b/integration-cli/docker_cli_pull_local_test.go
+index 64d3214..a0eb10a 100644
+--- a/integration-cli/docker_cli_pull_local_test.go
++++ b/integration-cli/docker_cli_pull_local_test.go
+@@ -228,3 +228,147 @@ func (s *DockerRegistrySuite) TestPullIDStability(c *check.C) {
+ 		c.Fatalf("expected %s; got %s", derivedImage, out)
+ 	}
+ }
++
++// Test pulls from blocked public registry and from private registry. This
++// shall be called with various daemonArgs containing at least one
++// `--block-registry` flag.
++func (s *DockerRegistrySuite) doTestPullFromBlockedPublicRegistry(c *check.C, daemonArgs []string) {
++	allBlocked := false
++	for _, arg := range daemonArgs {
++		if arg == "--block-registry=all" {
++			allBlocked = true
++		}
++	}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	busyboxID := s.d.getAndTestImageEntry(c, 1, "busybox", "").id
++
++	// try to pull from docker.io
++	if out, err := s.d.Cmd("pull", "library/hello-world"); err == nil {
++		c.Fatalf("pull from blocked public registry should have failed, output: %s", out)
++	}
++
++	// tag busybox as library/hello-world and push it to some private registry
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg.url+"/library/hello-world"); !allBlocked && err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/hello-world", err, out)
++	} else if allBlocked && err == nil {
++		c.Fatalf("push to private registry should have failed, output: %q", out)
++	}
++
++	// remove library/hello-world image
++	if out, err := s.d.Cmd("rmi", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", s.reg.url+"/library/hello-world", err, out)
++	}
++	s.d.getAndTestImageEntry(c, 1, "busybox", busyboxID)
++
++	// try to pull from private registry
++	if out, err := s.d.Cmd("pull", s.reg.url+"/library/hello-world"); !allBlocked && err != nil {
++		c.Fatalf("we should have been able to pull %s/library/hello-world: %v", s.reg.url, err)
++	} else if allBlocked && err == nil {
++		c.Fatalf("pull from private registry should have failed, output: %q", out)
++	} else if !allBlocked {
++		s.d.getAndTestImageEntry(c, 2, s.reg.url+"/library/hello-world", busyboxID)
++	}
++}
++
++func (s *DockerRegistrySuite) TestPullFromBlockedPublicRegistry(c *check.C) {
++	for _, blockedRegistry := range []string{"public", "docker.io"} {
++		s.doTestPullFromBlockedPublicRegistry(c, []string{"--block-registry=" + blockedRegistry})
++		s.d.Stop()
++		s.d = NewDaemon(c)
++	}
++}
++
++func (s *DockerRegistrySuite) TestPullWithAllRegistriesBlocked(c *check.C) {
++	s.doTestPullFromBlockedPublicRegistry(c, []string{"--block-registry=all"})
++}
++
++// Test pulls from additional registry with public registry blocked. This
++// shall be called with various daemonArgs containing at least one
++// `--block-registry` flag.
++func (s *DockerRegistriesSuite) doTestPullFromPrivateRegistriesWithPublicBlocked(c *check.C, daemonArgs []string) {
++	allBlocked := false
++	for _, arg := range daemonArgs {
++		if arg == "--block-registry=all" {
++			allBlocked = true
++		}
++	}
++	daemonArgs = append(daemonArgs, "--add-registry="+s.reg1.url)
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// try to pull from blocked public registry
++	if out, err := s.d.Cmd("pull", "library/hello-world"); err == nil {
++		c.Fatalf("pulling from blocked public registry should have failed, output: %s", out)
++	}
++
++	// push busybox to
++	//  additional registry as "misc/busybox"
++	//  private registry as "library/busybox"
++	// and remove all local images
++	if out, err := s.d.Cmd("tag", "busybox", s.reg1.url+"/misc/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", s.reg2.url+"/library/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg1.url+"/misc/busybox"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg1.url+"/misc/busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg2.url+"/library/busybox"); !allBlocked && err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg2.url+"/library/busybox", err, out)
++	} else if allBlocked && err == nil {
++		c.Fatalf("push to private registry should have failed, output: %q", out)
++	}
++	toRemove := []string{"busybox", "misc/busybox", s.reg2.url + "/library/busybox"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// try to pull "library/busybox" from additional registry
++	if out, err := s.d.Cmd("pull", "library/busybox"); err == nil {
++		c.Fatalf("pull of library/busybox from additional registry should have failed, output: %q", out)
++	}
++
++	// now pull the "misc/busybox" from additional registry
++	if _, err := s.d.Cmd("pull", "misc/busybox"); err != nil {
++		c.Fatalf("we should have been able to pull misc/hello-world from %q: %v", s.reg1.url, err)
++	}
++	bb2Img := s.d.getAndTestImageEntry(c, 1, s.reg1.url+"/misc/busybox", "")
++	if bb2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb2Img.name, bbImg.name, bb2Img.size, bbImg.size)
++	}
++
++	// try to pull "library/busybox" from private registry
++	if out, err := s.d.Cmd("pull", s.reg2.url+"/library/busybox"); !allBlocked && err != nil {
++		c.Fatalf("we should have been able to pull %s/library/busybox: %v", s.reg2.url, err)
++	} else if allBlocked && err == nil {
++		c.Fatalf("pull from private registry should have failed, output: %q", out)
++	} else if !allBlocked {
++		bb3Img := s.d.getAndTestImageEntry(c, 2, s.reg2.url+"/library/busybox", "")
++		if bb3Img.size != bbImg.size {
++			c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb3Img.name, bbImg.name, bb3Img.size, bbImg.size)
++		}
++	}
++}
++
++func (s *DockerRegistriesSuite) TestPullFromPrivateRegistriesWithPublicBlocked(c *check.C) {
++	for _, blockedRegistry := range []string{"public", "docker.io"} {
++		s.doTestPullFromPrivateRegistriesWithPublicBlocked(c, []string{"--block-registry=" + blockedRegistry})
++		s.d.Stop()
++		s.d = NewDaemon(c)
++	}
++}
++
++func (s *DockerRegistriesSuite) TestPullFromAdditionalRegistryWithAllBlocked(c *check.C) {
++	s.doTestPullFromPrivateRegistriesWithPublicBlocked(c, []string{"--block-registry=all"})
++}
+diff --git a/integration-cli/docker_cli_pull_test.go b/integration-cli/docker_cli_pull_test.go
+index 8ea31a7..bd6c1b0 100644
+--- a/integration-cli/docker_cli_pull_test.go
++++ b/integration-cli/docker_cli_pull_test.go
+@@ -19,11 +19,11 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *check.C) {
+ 	defer deleteImages("hello-world")
+ 
+ 	c.Assert(out, checker.Contains, "Using default tag: latest", check.Commentf("expected the 'latest' tag to be automatically assumed"))
+-	c.Assert(out, checker.Contains, "Pulling from library/hello-world", check.Commentf("expected the 'library/' prefix to be automatically assumed"))
+-	c.Assert(out, checker.Contains, "Downloaded newer image for hello-world:latest")
++	c.Assert(regexp.MustCompile(`Pulling.*from.*library/hello-world\b`).MatchString(out), checker.Equals, true, check.Commentf("expected the 'library/' prefix to be automatically assumed in: %s", out))
++	c.Assert(out, checker.Contains, "Downloaded newer image for docker.io/hello-world:latest")
+ 
+ 	matches := regexp.MustCompile(`Digest: (.+)\n`).FindAllStringSubmatch(out, -1)
+-	c.Assert(len(matches), checker.Equals, 1, check.Commentf("expected exactly one image digest in the output"))
++	c.Assert(len(matches), checker.Equals, 1, check.Commentf("expected exactly one image digest in the output: %s", out))
+ 	c.Assert(len(matches[0]), checker.Equals, 2, check.Commentf("unexpected number of submatches for the digest"))
+ 	_, err := digest.ParseDigest(matches[0][1])
+ 	c.Check(err, checker.IsNil, check.Commentf("invalid digest %q in output", matches[0][1]))
+@@ -32,7 +32,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *check.C) {
+ 	img := strings.TrimSpace(s.Cmd(c, "images"))
+ 	if splitImg := strings.Split(img, "\n"); len(splitImg) != 2 {
+ 		c.Fatalf("expected only two lines in the output of `docker images`, got %d", len(splitImg))
+-	} else if re := regexp.MustCompile(`^hello-world\s+latest`); !re.Match([]byte(splitImg[1])) {
++	} else if re := regexp.MustCompile(`^docker\.io/hello-world\s+latest`); !re.Match([]byte(splitImg[1])) {
+ 		c.Fatal("invalid output for `docker images` (expected image and tag name")
+ 	}
+ }
+@@ -76,14 +76,14 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistryImplicitRefParts(c *chec
+ 		"index.docker.io/library/hello-world",
+ 	} {
+ 		out := s.Cmd(c, "pull", i)
+-		c.Assert(out, checker.Contains, "Image is up to date for hello-world:latest")
++		c.Assert(out, checker.Contains, "Image is up to date for docker.io/hello-world:latest")
+ 	}
+ 
+ 	// We should have a single entry in images.
+ 	img := strings.TrimSpace(s.Cmd(c, "images"))
+ 	if splitImg := strings.Split(img, "\n"); len(splitImg) != 2 {
+ 		c.Fatalf("expected only two lines in the output of `docker images`, got %d", len(splitImg))
+-	} else if re := regexp.MustCompile(`^hello-world\s+latest`); !re.Match([]byte(splitImg[1])) {
++	} else if re := regexp.MustCompile(`^docker\.io/hello-world\s+latest`); !re.Match([]byte(splitImg[1])) {
+ 		c.Fatal("invalid output for `docker images` (expected image and tag name")
+ 	}
+ }
+@@ -115,7 +115,7 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
+ 	// Verify that the line for 'busybox:latest' is left unchanged.
+ 	var latestLine string
+ 	for _, line := range strings.Split(outImageAllTagCmd, "\n") {
+-		if strings.HasPrefix(line, "busybox") && strings.Contains(line, "latest") {
++		if strings.HasPrefix(line, "docker.io/busybox") && strings.Contains(line, "latest") {
+ 			latestLine = line
+ 			break
+ 		}
+@@ -166,3 +166,209 @@ func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
+ 		c.Fatal("image was pulled after client disconnected")
+ 	}
+ }
++
++func (s *DockerRegistrySuite) TestPullFromAdditionalRegistry(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, Network)
++
++	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// this will pull from docker.io
++	if _, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from %q: %v", s.reg.url, err)
++	}
++
++	hwImg := s.d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
++	if hwImg.id == bbImg.id || hwImg.size == bbImg.size {
++		c.Fatalf("docker.io/hello-world must have different ID and size than busybox image")
++	}
++
++	// push busybox to additional registry as "library/hello-world" and remove all local images
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/hello-world", err, out)
++	}
++	toRemove := []string{"library/hello-world", "busybox", "docker.io/hello-world"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// pull the same name again - now the image should be pulled from additional registry
++	if _, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from %q: %v", s.reg.url, err)
++	}
++	hw2Img := s.d.getAndTestImageEntry(c, 1, s.reg.url+"/library/hello-world", "")
++	if hw2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", hw2Img.name, bbImg.name, hw2Img.size, hwImg.size)
++	}
++
++	// empty images once more
++	if out, err := s.d.Cmd("rmi", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to remove image %s: %v, output: %s", s.reg.url+"library/hello-world", err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// now pull with fully qualified name
++	if _, err := s.d.Cmd("pull", "docker.io/library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull docker.io/library/hello-world from %q: %v", s.reg.url, err)
++	}
++	hw3Img := s.d.getAndTestImageEntry(c, 1, "docker.io/hello-world", "")
++	if hw3Img.size != hwImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", hw3Img.name, hwImg.name, hw3Img.size, hwImg.size)
++	}
++}
++
++func (s *DockerRegistriesSuite) TestPullFromAdditionalRegistries(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, Network)
++
++	daemonArgs := []string{"--add-registry=" + s.reg1.url, "--add-registry=" + s.reg2.url}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// this will pull from docker.io
++	if out, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from \"docker.io\": %s\n\nError:%v", out, err)
++	}
++	hwImg := s.d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
++	if hwImg.id == bbImg.id {
++		c.Fatalf("docker.io/hello-world must have different ID than busybox image")
++	}
++
++	// push:
++	//  hello-world to 1st additional registry as "misc/hello-world"
++	//  busybox to 2nd additional registry as "library/hello-world"
++	if out, err := s.d.Cmd("tag", "docker.io/hello-world", s.reg1.url+"/misc/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "docker.io/hello-world", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "/busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg1.url+"/misc/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg1.url+"/misc/hello-world", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg2.url+"/library/busybox", err, out)
++	}
++	// and remove all local images
++	toRemove := []string{"misc/hello-world", s.reg2.url + "/library/hello-world", "busybox", "docker.io/hello-world"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// now pull the "library/hello-world" from 2nd additional registry
++	if _, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from %q: %v", s.reg2.url, err)
++	}
++	hw2Img := s.d.getAndTestImageEntry(c, 1, s.reg2.url+"/library/hello-world", "")
++	if hw2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", hw2Img.name, bbImg.name, hw2Img.size, bbImg.size)
++	}
++
++	// now pull the "misc/hello-world" from 1st additional registry
++	if _, err := s.d.Cmd("pull", "misc/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull misc/hello-world from %q: %v", s.reg2.url, err)
++	}
++	hw3Img := s.d.getAndTestImageEntry(c, 2, s.reg1.url+"/misc/hello-world", "")
++	if hw3Img.size != hwImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", hw3Img.name, hwImg.name, hw3Img.size, hwImg.size)
++	}
++
++	// tag it as library/hello-world and push it to 1st registry
++	if out, err := s.d.Cmd("tag", s.reg1.url+"/misc/hello-world", s.reg1.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", s.reg1.url+"/misc/hello-world", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg1.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg1.url+"/library/hello-world", err, out)
++	}
++
++	// remove all images
++	toRemove = []string{s.reg1.url + "/misc/hello-world", s.reg1.url + "/library/hello-world", s.reg2.url + "/library/hello-world"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// now pull "library/hello-world" from 1st additional registry
++	if _, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from %q: %v", s.reg1.url, err)
++	}
++	hw4Img := s.d.getAndTestImageEntry(c, 1, s.reg1.url+"/library/hello-world", "")
++	if hw4Img.size != hwImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", hw4Img.name, hwImg.name, hw4Img.size, hwImg.size)
++	}
++
++	// now pull fully qualified image from 2nd registry
++	if _, err := s.d.Cmd("pull", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull %s/library/hello-world: %v", s.reg2.url, err)
++	}
++	bb2Img := s.d.getAndTestImageEntry(c, 2, s.reg2.url+"/library/hello-world", "")
++	if bb2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb2Img.name, bbImg.name, bb2Img.size, bbImg.size)
++	}
++}
++
++func (s *DockerRegistriesSuite) TestPullFromBlockedRegistry(c *check.C) {
++	testRequires(c, DaemonIsLinux)
++	testRequires(c, Network)
++
++	daemonArgs := []string{"--block-registry=" + s.reg1.url, "--add-registry=" + s.reg2.url}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// pull image from docker.io
++	if _, err := s.d.Cmd("pull", "library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from \"docker.io\": %v", err)
++	}
++	hwImg := s.d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
++	if hwImg.size == bbImg.size {
++		c.Fatalf("docker.io/hello-world must have different size than busybox image")
++	}
++
++	// push "hello-world" to blocked and additional registry and remove all local images
++	if out, err := s.d.Cmd("tag", "busybox", s.reg1.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg1.url+"/library/hello-world"); err == nil {
++		c.Fatalf("push to blocked registry should have failed, output: %q", out)
++	}
++	if out, err := s.d.Cmd("push", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg2.url+"/library/hello-world", err, out)
++	}
++	toRemove := []string{"library/hello-world", s.reg1.url + "/library/hello-world", "docker.io/hello-world", "busybox"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// try to pull "library/hello-world" from blocked registry
++	if out, err := s.d.Cmd("pull", s.reg1.url+"/library/hello-world"); err == nil {
++		c.Fatalf("pull of library/hello-world from additional registry should have failed, output: %q", out)
++	}
++
++	// now pull the "library/hello-world" from additional registry
++	if _, err := s.d.Cmd("pull", s.reg2.url+"/library/hello-world"); err != nil {
++		c.Fatalf("we should have been able to pull library/hello-world from %q: %v", s.reg2.url, err)
++	}
++	bb2Img := s.d.getAndTestImageEntry(c, 1, s.reg2.url+"/library/hello-world", "")
++	if bb2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb2Img.name, bbImg.name, bb2Img.size, bbImg.size)
++	}
++}
+diff --git a/integration-cli/docker_cli_push_test.go b/integration-cli/docker_cli_push_test.go
+index 79ac272..3e7a6be 100644
+--- a/integration-cli/docker_cli_push_test.go
++++ b/integration-cli/docker_cli_push_test.go
+@@ -2,10 +2,13 @@ package main
+ 
+ import (
+ 	"archive/tar"
++	"bufio"
+ 	"fmt"
++	"io"
+ 	"io/ioutil"
+ 	"os"
+ 	"os/exec"
++	"regexp"
+ 	"strings"
+ 	"time"
+ 
+@@ -303,3 +306,107 @@ func (s *DockerTrustSuite) TestTrustedPushWithExpiredTimestamp(c *check.C) {
+ 		c.Assert(out, checker.Contains, "Signing and pushing trust metadata", check.Commentf("Missing expected output on trusted push with expired timestamp"))
+ 	})
+ }
++
++func (s *DockerSuite) TestPushOfficialImage(c *check.C) {
++	var reErr = regexp.MustCompile(`rename your repository to[^:]*:\s*docker\.io/<user>/busybox\b`)
++
++	// push busybox to public registry as "library/busybox"
++	cmd := exec.Command(dockerBinary, "push", "library/busybox")
++	stdout, err := cmd.StdoutPipe()
++	if err != nil {
++		c.Fatalf("Failed to get stdout pipe for process: %v", err)
++	}
++	stderr, err := cmd.StderrPipe()
++	if err != nil {
++		c.Fatalf("Failed to get stderr pipe for process: %v", err)
++	}
++	if err := cmd.Start(); err != nil {
++		c.Fatalf("Failed to start pushing to public registry: %v", err)
++	}
++	outReader := bufio.NewReader(stdout)
++	errReader := bufio.NewReader(stderr)
++	line, isPrefix, err := errReader.ReadLine()
++	if err != nil {
++		c.Fatalf("Failed to read farewell: %v", err)
++	}
++	if isPrefix {
++		c.Errorf("Got unexpectedly long output.")
++	}
++	if !reErr.Match(line) {
++		c.Errorf("Got unexpected output %q", line)
++	}
++	if line, _, err = outReader.ReadLine(); err != io.EOF {
++		c.Errorf("Expected EOF, not: %q", line)
++	}
++	for ; err != io.EOF; line, _, err = errReader.ReadLine() {
++		c.Errorf("Expected no message on stderr, got: %q", string(line))
++	}
++
++	// Wait for command to finish with short timeout.
++	finish := make(chan struct{})
++	go func() {
++		if err := cmd.Wait(); err == nil {
++			c.Error("Push command should have failed.")
++		}
++		close(finish)
++	}()
++	select {
++	case <-finish:
++	case <-time.After(1 * time.Second):
++		c.Fatalf("Docker push failed to exit.")
++	}
++}
++
++func (s *DockerRegistrySuite) TestPushToAdditionalRegistry(c *check.C) {
++	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// push busybox to additional registry as "library/busybox" and remove all local images
++	if out, err := s.d.Cmd("tag", "busybox", "library/busybox"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", "library/busybox"); err != nil {
++		c.Fatalf("failed to push image library/busybox: error %v, output %q", err, out)
++	}
++	toRemove := []string{"busybox", "library/busybox"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// pull it from additional registry
++	if _, err := s.d.Cmd("pull", "library/busybox"); err != nil {
++		c.Fatalf("we should have been able to pull library/busybox from %q: %v", s.reg.url, err)
++	}
++	bb2Img := s.d.getAndTestImageEntry(c, 1, s.reg.url+"/library/busybox", "")
++	if bb2Img.size != bbImg.size {
++		c.Fatalf("expected %s and %s to have the same size (%s != %s)", bb2Img.name, bbImg.name, bb2Img.size, bbImg.size)
++	}
++}
++
++func (s *DockerRegistrySuite) TestPushCustomTagToAdditionalRegistry(c *check.C) {
++	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
++	}
++
++	busyboxID := s.d.getAndTestImageEntry(c, 1, "busybox", "").id
++
++	if out, err := s.d.Cmd("tag", "busybox", "user/busybox:1.2.3"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/user/busybox:latest"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", "busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", "user/busybox:1.2.3"); err != nil {
++		c.Fatalf("failed to push image user/busybox: error %v, output %q", err, out)
++	}
++	s.d.getAndTestImageEntry(c, 3, "user/busybox", busyboxID)
++	toRemove := []string{"user/busybox:1.2.3"}
++	if out, err := s.d.Cmd("rmi", toRemove...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", toRemove, err, out)
++	}
++	s.d.getAndTestImageEntry(c, 2, s.reg.url+"/user/busybox", busyboxID)
++}
+diff --git a/integration-cli/docker_cli_rmi_test.go b/integration-cli/docker_cli_rmi_test.go
+index 2f456e8..233c94c 100644
+--- a/integration-cli/docker_cli_rmi_test.go
++++ b/integration-cli/docker_cli_rmi_test.go
+@@ -3,6 +3,7 @@ package main
+ import (
+ 	"fmt"
+ 	"os/exec"
++	"regexp"
+ 	"strings"
+ 
+ 	"github.com/docker/docker/pkg/integration/checker"
+@@ -13,14 +14,34 @@ import (
+ func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
+ 	testRequires(c, DaemonIsLinux)
+ 	errSubstr := "is using it"
++	imageName := regexp.MustCompile(`(?m)^([^/ ]+/busybox)\s+`)
++
++	// remove any fully-qualified busybox images created by prior tests
++	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "images"))
++	if err != nil {
++		c.Fatalf("failed to list images: %v", err)
++	}
++	args := []string{"rmi", "-f"}
++	for _, name := range imageName.FindAllStringSubmatch(out, -1) {
++		args = append(args, name[1])
++	}
++	if len(args) > 2 {
++		rmiCmd := exec.Command(dockerBinary, args...)
++		if out, _, err = runCommandWithOutput(rmiCmd); err != nil {
++			c.Errorf("failed to remove all fully-qualified busybox images: %s, %v", out, err)
++		}
++	}
+ 
+ 	// create a container
+-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
++	out, _, err = dockerCmdWithError("run", "-d", "busybox", "true")
++	if err != nil {
++		c.Fatalf("failed to create a container: %s, %v", out, err)
++	}
+ 
+ 	cleanedContainerID := strings.TrimSpace(out)
+ 
+ 	// try to delete the image
+-	out, _, err := dockerCmdWithError("rmi", "busybox")
++	out, _, err = dockerCmdWithError("rmi", "busybox")
+ 	// Container is using image, should not be able to rmi
+ 	c.Assert(err, checker.NotNil)
+ 	// Container is using image, error message should contain errSubstr
+diff --git a/integration-cli/docker_cli_run_test.go b/integration-cli/docker_cli_run_test.go
+index 3bab96f..d70f303 100644
+--- a/integration-cli/docker_cli_run_test.go
++++ b/integration-cli/docker_cli_run_test.go
+@@ -3924,3 +3924,73 @@ func (s *DockerSuite) TestRunNamedVolumesMountedAsShared(c *check.C) {
+ 	}
+ 
+ }
++
++func (s *DockerRegistrySuite) TestRunWithAdditionalRegistry(c *check.C) {
++	if err := s.d.StartWithBusybox("--add-registry=" + s.reg.url); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing add-registry=%s: %v", s.reg.url, err)
++	}
++
++	bbImg := s.d.getAndTestImageEntry(c, 1, "busybox", "")
++
++	// push busybox to additional registry as "library/hello-world" and remove all local images
++	if out, err := s.d.Cmd("tag", "busybox", s.reg.url+"/busybox"); err != nil {
++		c.Fatalf("failed to tag image busybox: error %v, output %q", err, out)
++	}
++	if out, err := s.d.Cmd("rmi", "busybox"); err != nil {
++		c.Fatalf("failed to remove image busybox: %v, output: %s", err, out)
++	}
++	s.d.getAndTestImageEntry(c, 1, s.reg.url+"/busybox", bbImg.id)
++
++	// try to run fully qualified image
++	if out, err := s.d.Cmd("run", "-t", s.reg.url+"/busybox", "sh", "-c", "echo foo"); err != nil {
++		c.Fatalf("failed to run %s/busybox image: %v, output: %s", s.reg.url, err, out)
++	} else if strings.TrimSpace(out) != "foo" {
++		c.Fatalf("got unexpected output: %q", out)
++	}
++
++	// try to run unqualified
++	if out, err := s.d.Cmd("run", "-t", "busybox", "sh", "-c", "echo foo"); err != nil {
++		c.Fatalf("failed to run busybox image: %v, output: %s", err, out)
++	} else if out != "foo\r\n" {
++		c.Fatalf("got unexpected output: %q", out)
++	}
++
++	// try to run hello world from additional registry
++	if out, err := s.d.Cmd("run", "-t", s.reg.url+"/library/hello-world", "sh", "-c", "echo foo"); err == nil {
++		c.Fatalf("running container from image %s/library/hello-world should have failed; output: %s", s.reg.url, out)
++	}
++
++	// try to run hello-world from official registry
++	if out, err := s.d.Cmd("run", "-t", "library/hello-world"); err != nil {
++		c.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
++	} else if strings.HasSuffix(strings.TrimSpace(out), "foo") {
++		c.Fatalf("got unexpected output")
++	}
++	s.d.getAndTestImageEntry(c, 2, "docker.io/hello-world", "")
++
++	// push busybox to additional registry as "library/hello-world" and remove all local images
++	if out, err := s.d.Cmd("tag", s.reg.url+"/busybox", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to tag image %s: error %v, output %q", s.reg.url+"/busybox", err, out)
++	}
++	if out, err := s.d.Cmd("push", s.reg.url+"/library/hello-world"); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", s.reg.url+"/library/hello-world", err, out)
++	}
++	args := []string{"-f", "hello-world", "library/hello-world", "busybox"}
++	if out, err := s.d.Cmd("rmi", args...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", args[1:], err, out)
++	}
++	s.d.getAndTestImageEntry(c, 0, "", "")
++
++	// now try to run unqualified hello-world again - this time we should pull from additional registry
++	if out, err := s.d.Cmd("run", "-t", "library/hello-world", "sh", "-c", "echo foo"); err != nil {
++		c.Fatalf("failed to run library/hello-world image: %v, output: %s", err, out)
++	} else if !strings.HasSuffix(strings.TrimSpace(out), "\nfoo") {
++		c.Fatalf("got unexpected output: %q", out)
++	}
++	// image id now differs from busybox because ids are generated again upon full pull
++	hwImg := s.d.getAndTestImageEntry(c, 1, s.reg.url+"/library/hello-world", "")
++	// therefore we need to compare size
++	if bbImg.size != hwImg.size {
++		c.Fatalf("expected %s:%s and %s:%s to have equal size (%s != %s)", hwImg.name, hwImg.tag, bbImg.name, bbImg.tag, hwImg.size, bbImg.size)
++	}
++}
+diff --git a/integration-cli/docker_cli_tag_test.go b/integration-cli/docker_cli_tag_test.go
+index 7e27a75..5739165 100644
+--- a/integration-cli/docker_cli_tag_test.go
++++ b/integration-cli/docker_cli_tag_test.go
+@@ -135,7 +135,7 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
+ 		out, _, err = dockerCmdWithError("images")
+ 		if err != nil {
+ 			c.Errorf("listing images failed with errors: %v, %s", err, out)
+-		} else if strings.Contains(out, name) {
++		} else if strings.Contains(out, name) && name != "docker.io/busybox" {
+ 			c.Errorf("images should not have listed '%s'", name)
+ 			deleteImages(name + ":latest")
+ 		}
+diff --git a/integration-cli/docker_test_vars.go b/integration-cli/docker_test_vars.go
+index e876736..00d16d3 100644
+--- a/integration-cli/docker_test_vars.go
++++ b/integration-cli/docker_test_vars.go
+@@ -17,7 +17,8 @@ var (
+ 	registryImageName = "registry"
+ 
+ 	// the private registry to use for tests
+-	privateRegistryURL = "127.0.0.1:5000"
++	privateRegistryURL  = "127.0.0.1:5000"
++	privateRegistryURL2 = "127.0.0.1:5001"
+ 
+ 	runtimePath    = "/var/run/docker"
+ 	execDriverPath = runtimePath + "/execdriver/native"
+diff --git a/integration-cli/docker_utils.go b/integration-cli/docker_utils.go
+index 5580032..1f55584 100644
+--- a/integration-cli/docker_utils.go
++++ b/integration-cli/docker_utils.go
+@@ -18,6 +18,7 @@ import (
+ 	"os/exec"
+ 	"path"
+ 	"path/filepath"
++	"regexp"
+ 	"strconv"
+ 	"strings"
+ 	"time"
+@@ -126,6 +127,10 @@ type clientConfig struct {
+ 	addr      string
+ }
+ 
++type localImageEntry struct {
++	name, tag, id, size string
++}
++
+ // NewDaemon returns a Daemon instance to be used for testing.
+ // This will create a directory such as d123456789 in the folder specified by $DEST.
+ // The daemon will not automatically start.
+@@ -474,6 +479,110 @@ func (d *Daemon) LogfileName() string {
+ 	return d.logFile.Name()
+ }
+ 
++func (d *Daemon) buildImageWithOut(name, dockerfile string, useCache bool) (string, string, error) {
++	args := []string{"--host", d.sock(), "build", "-t", name}
++	if !useCache {
++		args = append(args, "--no-cache")
++	}
++	args = append(args, "-")
++	c := exec.Command(dockerBinary, args...)
++	c.Stdin = strings.NewReader(dockerfile)
++	out, err := c.CombinedOutput()
++	if err != nil {
++		return "", string(out), fmt.Errorf("failed to build the image: %s", out)
++	}
++	id, err := d.inspectField(name, "Id")
++	if err != nil {
++		return "", string(out), err
++	}
++	return id, string(out), nil
++}
++
++// getImages lists images of given Docker daemon and returns it in a
++// map with keys in form <name>:<tag>.
++func (d *Daemon) getImages(c *check.C, args ...string) map[string]*localImageEntry {
++	reImageEntry := regexp.MustCompile(`(?m)^([[:alnum:]/.:_<>-]+)\s+([[:alnum:]._<>-]+)\s+((?:sha\d+:)?[a-fA-F0-9]+)\s+\S+\s+(.+)`)
++	result := make(map[string]*localImageEntry)
++
++	out, err := d.Cmd("images", args...)
++	if err != nil {
++		c.Fatalf("failed to list images: %v", err)
++	}
++	matches := reImageEntry.FindAllStringSubmatch(out, -1)
++	if matches != nil {
++		for i, match := range matches {
++			if i < 1 && match[1] == "REPOSITORY" {
++				continue // skip header
++			}
++			key := match[1]
++			if match[2] != "" && match[2] != "<none>" {
++				key += ":" + match[2]
++			}
++			result[key] = &localImageEntry{match[1], match[2], match[3], match[4]}
++		}
++	}
++	return result
++}
++
++// getAndTestImageEntry lists  images of given Docker daemon and assert
++// expected values. Unless expectedImageCount is negative, assert the number of
++// images of Docker daemon. Unless repoName is empty, assert it exists and
++// return its matching localImageEntry. If the tag is missing, it won't be
++// checked. Unless expectedImageID is empty, assert that image ID of given
++// repoName matches this one.
++func (d *Daemon) getAndTestImageEntry(c *check.C, expectedImageCount int, repoName, expectedImageID string) *localImageEntry {
++	reRefTagged := regexp.MustCompile(`^(.*):([^:/]+)$`)
++	images := d.getImages(c)
++	if expectedImageCount >= 0 && len(images) != expectedImageCount {
++		switch expectedImageCount {
++		case 0:
++			c.Fatalf("expected empty local image database, got %d images", len(images))
++		case 1:
++			c.Fatalf("expected exactly 1 local image, got %d", len(images))
++		default:
++			c.Fatalf("expected exactly %d local images, got %d", expectedImageCount, len(images))
++		}
++	}
++
++	matchTag := reRefTagged.MatchString(repoName)
++
++	if repoName != "" {
++		img, found := images[repoName]
++		if !found {
++			keys := make([]string, 0, len(images))
++			for k := range images {
++				if !matchTag {
++					if strings.HasPrefix(k, repoName+":") {
++						found = true
++						img = images[k]
++						break
++					}
++				}
++				keys = append(keys, k)
++			}
++			if !found {
++				c.Fatalf("%s missing in list of images: %v", repoName, keys)
++			}
++		}
++
++		if expectedImageID != "" && img.id != expectedImageID {
++			c.Fatalf("image ID of %s does not match expected (%s != %s)", repoName, img.id, expectedImageID)
++		}
++
++		return img
++	}
++	return nil
++}
++
++func (d *Daemon) inspectField(name, field string) (string, error) {
++	format := fmt.Sprintf("{{.%s}}", field)
++	out, err := d.Cmd("inspect", "-f", format, name)
++	if err != nil {
++		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
++	}
++	return strings.TrimSpace(out), nil
++}
++
+ func daemonHost() string {
+ 	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+ 	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
+@@ -600,11 +709,16 @@ func readBody(b io.ReadCloser) ([]byte, error) {
+ 
+ func deleteContainer(container string) error {
+ 	container = strings.TrimSpace(strings.Replace(container, "\n", " ", -1))
++	if container == "" {
++		return nil
++	}
+ 	rmArgs := strings.Split(fmt.Sprintf("rm -fv %v", container), " ")
+-	exitCode, err := runCommand(exec.Command(dockerBinary, rmArgs...))
++	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, rmArgs...))
+ 	// set error manually if not set
+ 	if exitCode != 0 && err == nil {
+-		err = fmt.Errorf("failed to remove container: `docker rm` exit is non-zero")
++		err = fmt.Errorf("failed to remove container: `docker rm` exit is non-zero: \n%s", out)
++	} else if err != nil {
++		err = fmt.Errorf("failed to remove container: %v\n%s", err, out)
+ 	}
+ 
+ 	return err
+@@ -624,11 +738,13 @@ func deleteAllContainers() error {
+ 	containers, err := getAllContainers()
+ 	if err != nil {
+ 		fmt.Println(containers)
++		fmt.Fprintf(os.Stderr, "deleteAllContainers: %v\n", err)
+ 		return err
+ 	}
+ 
+ 	if containers != "" {
+ 		if err = deleteContainer(containers); err != nil {
++			fmt.Fprintf(os.Stderr, "failed to delete containers %s: %v\n", containers, err)
+ 			return err
+ 		}
+ 	}
+@@ -682,10 +798,13 @@ func deleteAllVolumes() error {
+ 		status, b, err := sockRequest("DELETE", "/volumes/"+v.Name, nil)
+ 		if err != nil {
+ 			errors = append(errors, err.Error())
++			fmt.Fprintf(os.Stderr, "deleteAllVolumes: %s\n", err.Error())
+ 			continue
+ 		}
+ 		if status != http.StatusNoContent {
+-			errors = append(errors, fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b)))
++			errMsg := fmt.Sprintf("error deleting volume %s: %s", v.Name, string(b))
++			fmt.Fprintf(os.Stderr, "%s\n", errMsg)
++			errors = append(errors, errMsg)
+ 		}
+ 	}
+ 	if len(errors) > 0 {
+@@ -709,7 +828,7 @@ func getAllVolumes() ([]*types.Volume, error) {
+ var protectedImages = map[string]struct{}{}
+ 
+ func deleteAllImages() error {
+-	out, err := exec.Command(dockerBinary, "images").CombinedOutput()
++	out, err := exec.Command(dockerBinary, "images", "--digests").CombinedOutput()
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -720,20 +839,29 @@ func deleteAllImages() error {
+ 			continue
+ 		}
+ 		fields := strings.Fields(l)
+-		imgTag := fields[0] + ":" + fields[1]
+-		if _, ok := protectedImages[imgTag]; !ok {
++		imgRef := fields[0] + ":" + fields[1]
++		if fields[1] == "<none>" {
++			if fields[2] != "<none>" {
++				imgRef = fields[0] + "@" + fields[2]
++			} else {
++				imgRef = fields[0]
++			}
++		}
++		if _, ok := protectedImages[imgRef]; !ok {
+ 			if fields[0] == "<none>" {
+-				imgs = append(imgs, fields[2])
++				imgs = append(imgs, fields[3])
+ 				continue
+ 			}
+-			imgs = append(imgs, imgTag)
++			imgs = append(imgs, imgRef)
+ 		}
+ 	}
+ 	if len(imgs) == 0 {
+ 		return nil
+ 	}
+ 	args := append([]string{"rmi", "-f"}, imgs...)
+-	if err := exec.Command(dockerBinary, args...).Run(); err != nil {
++	rmiCmd := exec.Command(dockerBinary, args...)
++	if out, _, err := runCommandWithOutput(rmiCmd); err != nil {
++		fmt.Fprintf(os.Stderr, "removing unprotected images (%s): failed with: %v\n%s", strings.Join(imgs, ", "), err, out)
+ 		return err
+ 	}
+ 	return nil
+@@ -798,6 +926,7 @@ func deleteImages(images ...string) error {
+ 	exitCode, err := runCommand(rmiCmd)
+ 	// set error manually if not set
+ 	if exitCode != 0 && err == nil {
++		fmt.Fprintf(os.Stderr, "deleteImages: failed to remove images: %v\n", err)
+ 		err = fmt.Errorf("failed to remove image: `docker rmi` exit is non-zero")
+ 	}
+ 	return err
+@@ -1513,9 +1642,9 @@ func daemonTime(c *check.C) time.Time {
+ 	return dt
+ }
+ 
+-func setupRegistry(c *check.C) *testRegistryV2 {
++func setupRegistryAt(c *check.C, url string) *testRegistryV2 {
+ 	testRequires(c, RegistryHosting)
+-	reg, err := newTestRegistryV2(c)
++	reg, err := newTestRegistryV2At(c, url)
+ 	c.Assert(err, check.IsNil)
+ 
+ 	// Wait for registry to be ready to serve requests.
+@@ -1530,6 +1659,10 @@ func setupRegistry(c *check.C) *testRegistryV2 {
+ 	return reg
+ }
+ 
++func setupRegistry(c *check.C) *testRegistryV2 {
++	return setupRegistryAt(c, privateRegistryURL)
++}
++
+ func setupNotary(c *check.C) *testNotary {
+ 	testRequires(c, NotaryHosting)
+ 	ts, err := newTestNotary(c)
+diff --git a/integration-cli/registry.go b/integration-cli/registry.go
+index 35e1b4e..f66e799 100644
+--- a/integration-cli/registry.go
++++ b/integration-cli/registry.go
+@@ -16,10 +16,11 @@ const v2binary = "registry-v2"
+ 
+ type testRegistryV2 struct {
+ 	cmd *exec.Cmd
++	url string
+ 	dir string
+ }
+ 
+-func newTestRegistryV2(c *check.C) (*testRegistryV2, error) {
++func newTestRegistryV2At(c *check.C, url string) (*testRegistryV2, error) {
+ 	template := `version: 0.1
+ loglevel: debug
+ storage:
+@@ -36,7 +37,7 @@ http:
+ 	if err != nil {
+ 		return nil, err
+ 	}
+-	if _, err := fmt.Fprintf(config, template, tmp, privateRegistryURL); err != nil {
++	if _, err := fmt.Fprintf(config, template, tmp, url); err != nil {
+ 		os.RemoveAll(tmp)
+ 		return nil, err
+ 	}
+@@ -51,13 +52,18 @@ http:
+ 	}
+ 	return &testRegistryV2{
+ 		cmd: cmd,
++		url: url,
+ 		dir: tmp,
+ 	}, nil
+ }
+ 
++func newTestRegistryV2(c *check.C) (*testRegistryV2, error) {
++	return newTestRegistryV2At(c, privateRegistryURL)
++}
++
+ func (t *testRegistryV2) Ping() error {
+ 	// We always ping through HTTP for our test registry.
+-	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", privateRegistryURL))
++	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", t.url))
+ 	if err != nil {
+ 		return err
+ 	}
+diff --git a/man/docker-daemon.8.md b/man/docker-daemon.8.md
+index f06a05e..986d047 100644
+--- a/man/docker-daemon.8.md
++++ b/man/docker-daemon.8.md
+@@ -6,10 +6,12 @@ docker-daemon - Enable daemon mode
+ 
+ # SYNOPSIS
+ **docker daemon**
++[**--add-registry**[=*[]*]]
+ [**--api-cors-header**=[=*API-CORS-HEADER*]]
+ [**--authz-plugin**[=*[]*]]
+ [**-b**|**--bridge**[=*BRIDGE*]]
+ [**--bip**[=*BIP*]]
++[**--block-registry**[=*[]*]]
+ [**--cluster-store**[=*[]*]]
+ [**--cluster-advertise**[=*[]*]]
+ [**--cluster-store-opt**[=*map[]*]]
+@@ -68,6 +70,9 @@ format.
+ 
+ # OPTIONS
+ 
++**--add-registry**=[]
++  **EXPERIMENTAL** Each given registry will be queried before a public Docker registry during image pulls or searches. They will be searched in the order given. Registry mirrors won't apply to them.
++
+ **--api-cors-header**=""
+   Set CORS headers in the remote API. Default is cors disabled. Give urls like "http://foo, http://bar, ...". Give "*" to allow all.
+ 
+@@ -80,6 +85,9 @@ format.
+ **--bip**=""
+   Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
+ 
++**--block-registry**=[]
++  **EXPERIMENTAL** Prevent Docker daemon from contacting specified registries. There are two special keywords recognized. The first is "public" and represents public Docker registry. The second is "all" which causes all registries but those added with **--add-registry** flag to be blocked.
++
+ **--cluster-store**=""
+   URL of the distributed storage backend
+ 
+diff --git a/registry/config.go b/registry/config.go
+index 2eeba14..f8e80fb 100644
+--- a/registry/config.go
++++ b/registry/config.go
+@@ -36,9 +36,19 @@ const (
+ 	NotaryServer = "https://notary.docker.io"
+ 
+ 	// IndexServer = "https://registry-stage.hub.docker.com/v1/"
++
++	// OfficialReposNamePrefix is a remote name component of official
++	// repositories. It is stripped from repository local name.
++	OfficialReposNamePrefix = "library/"
+ )
+ 
+ var (
++	// BlockedRegistries is a set of registries that can't be contacted. A
++	// special entry "*" causes all registries but those present in
++	// RegistryList to be blocked.
++	BlockedRegistries map[string]struct{}
++	// RegistryList is a list of default registries..
++	RegistryList = []string{IndexName}
+ 	// ErrInvalidRepositoryName is an error returned if the repository name did
+ 	// not have the correct form
+ 	ErrInvalidRepositoryName = errors.New("Invalid repository name (ex: \"registry.domain.tld/myrepos\")")
+@@ -50,6 +60,29 @@ var (
+ 	V2Only = false
+ )
+ 
++func init() {
++	BlockedRegistries = make(map[string]struct{})
++}
++
++// IndexServerName returns the name of default index server.
++func IndexServerName() string {
++	if len(RegistryList) < 1 {
++		return ""
++	}
++	return RegistryList[0]
++}
++
++// IndexServerAddress returns index uri of default registry.
++func IndexServerAddress() string {
++	if IndexServerName() == IndexName {
++		return IndexServer
++	} else if IndexServerName() == "" {
++		return ""
++	} else {
++		return fmt.Sprintf("https://%s/v1/", IndexServerName())
++	}
++}
++
+ // InstallFlags adds command-line options to the top-level flag parser for
+ // the current process.
+ func (options *Options) InstallFlags(cmd *flag.FlagSet, usageFn func(string) string) {
+@@ -101,12 +134,22 @@ func NewServiceConfig(options *Options) *registrytypes.ServiceConfig {
+ 		}
+ 	}
+ 
+-	// Configure public registry.
+-	config.IndexConfigs[IndexName] = &registrytypes.IndexInfo{
+-		Name:     IndexName,
+-		Mirrors:  config.Mirrors,
+-		Secure:   true,
+-		Official: true,
++	for _, r := range RegistryList {
++		var mirrors []string
++		if config.IndexConfigs[r] == nil {
++			// Use mirrors only with official index
++			if r == IndexName {
++				mirrors = config.Mirrors
++			} else {
++				mirrors = make([]string, 0)
++			}
++			config.IndexConfigs[r] = &registrytypes.IndexInfo{
++				Name:     r,
++				Mirrors:  mirrors,
++				Secure:   isSecureIndex(config, r),
++				Official: r == IndexName,
++			}
++		}
+ 	}
+ 
+ 	return config
+@@ -129,6 +172,9 @@ func isSecureIndex(config *registrytypes.ServiceConfig, indexName string) bool {
+ 	if index, ok := config.IndexConfigs[indexName]; ok {
+ 		return index.Secure
+ 	}
++	if indexName == IndexName {
++		return true
++	}
+ 
+ 	host, _, err := net.SplitHostPort(indexName)
+ 	if err != nil {
+@@ -185,6 +231,14 @@ func ValidateIndexName(val string) (string, error) {
+ 	if val == "index."+IndexName {
+ 		val = IndexName
+ 	}
++	for _, r := range RegistryList {
++		if val == r {
++			break
++		}
++		if val == "index."+r {
++			val = r
++		}
++	}
+ 	if strings.HasPrefix(val, "-") || strings.HasSuffix(val, "-") {
+ 		return "", fmt.Errorf("Invalid index name (%s). Cannot begin or end with a hyphen.", val)
+ 	}
+@@ -223,7 +277,7 @@ func loadRepositoryName(reposName reference.Named) (string, reference.Named, err
+ 	if err := validateNoSchema(reposName.Name()); err != nil {
+ 		return "", nil, err
+ 	}
+-	indexName, remoteName, err := splitReposName(reposName)
++	indexName, remoteName, err := splitReposName(reposName, false)
+ 
+ 	if indexName, err = ValidateIndexName(indexName); err != nil {
+ 		return "", nil, err
+@@ -234,6 +288,13 @@ func loadRepositoryName(reposName reference.Named) (string, reference.Named, err
+ 	return indexName, remoteName, nil
+ }
+ 
++// IsReferenceFullyQualified determines whether the given reposName has prepended
++// name of index.
++func IsReferenceFullyQualified(reposName reference.Named) bool {
++	indexName, _, _ := splitReposName(reposName, false)
++	return indexName != ""
++}
++
+ // newIndexInfo returns IndexInfo configuration from indexName
+ func newIndexInfo(config *registrytypes.ServiceConfig, indexName string) (*registrytypes.IndexInfo, error) {
+ 	var err error
+@@ -251,9 +312,10 @@ func newIndexInfo(config *registrytypes.ServiceConfig, indexName string) (*regis
+ 	index := &registrytypes.IndexInfo{
+ 		Name:     indexName,
+ 		Mirrors:  make([]string, 0),
+-		Official: false,
++		Official: indexName == IndexName,
++		Secure:   isSecureIndex(config, indexName),
+ 	}
+-	index.Secure = isSecureIndex(config, indexName)
++
+ 	return index, nil
+ }
+ 
+@@ -267,14 +329,20 @@ func GetAuthConfigKey(index *registrytypes.IndexInfo) string {
+ }
+ 
+ // splitReposName breaks a reposName into an index name and remote name
+-func splitReposName(reposName reference.Named) (indexName string, remoteName reference.Named, err error) {
++// fixMissingIndex says to return current index server name if missing in
++// reposName
++func splitReposName(reposName reference.Named, fixMissingIndex bool) (indexName string, remoteName reference.Named, err error) {
+ 	var remoteNameStr string
+ 	indexName, remoteNameStr = reference.SplitHostname(reposName)
+ 	if indexName == "" || (!strings.Contains(indexName, ".") &&
+ 		!strings.Contains(indexName, ":") && indexName != "localhost") {
+ 		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
+ 		// 'docker.io'
+-		indexName = IndexName
++		if fixMissingIndex {
++			indexName = IndexServerName()
++		} else {
++			indexName = ""
++		}
+ 		remoteName = reposName
+ 	} else {
+ 		remoteName, err = reference.WithName(remoteNameStr)
+@@ -282,6 +350,23 @@ func splitReposName(reposName reference.Named) (indexName string, remoteName ref
+ 	return
+ }
+ 
++// IsIndexBlocked allows to check whether index/registry or endpoint
++// is on a block list.
++func IsIndexBlocked(indexName string) bool {
++	if _, ok := BlockedRegistries[indexName]; ok {
++		return true
++	}
++	if _, ok := BlockedRegistries["*"]; ok {
++		for _, name := range RegistryList {
++			if indexName == name {
++				return false
++			}
++		}
++		return true
++	}
++	return false
++}
++
+ // newRepositoryInfo validates and breaks down a repository name into a RepositoryInfo
+ func newRepositoryInfo(config *registrytypes.ServiceConfig, reposName reference.Named) (*RepositoryInfo, error) {
+ 	if err := validateNoSchema(reposName.Name()); err != nil {
+@@ -298,6 +383,9 @@ func newRepositoryInfo(config *registrytypes.ServiceConfig, reposName reference.
+ 	if err != nil {
+ 		return nil, err
+ 	}
++	if indexName == "" {
++		indexName = IndexServerName()
++	}
+ 
+ 	repoInfo.Index, err = newIndexInfo(config, indexName)
+ 	if err != nil {
+@@ -305,24 +393,28 @@ func newRepositoryInfo(config *registrytypes.ServiceConfig, reposName reference.
+ 	}
+ 
+ 	if repoInfo.Index.Official {
+-		repoInfo.LocalName, err = normalizeLibraryRepoName(repoInfo.RemoteName)
++		normalizedName, err := normalizeLibraryRepoName(repoInfo.RemoteName)
+ 		if err != nil {
+ 			return nil, err
+ 		}
+-		repoInfo.RemoteName = repoInfo.LocalName
++		repoInfo.RemoteName = normalizedName
+ 
+ 		// If the normalized name does not contain a '/' (e.g. "foo")
+ 		// then it is an official repo.
+ 		if strings.IndexRune(repoInfo.RemoteName.Name(), '/') == -1 {
+ 			repoInfo.Official = true
+ 			// Fix up remote name for official repos.
+-			repoInfo.RemoteName, err = reference.WithName("library/" + repoInfo.RemoteName.Name())
++			repoInfo.RemoteName, err = reference.WithName(OfficialReposNamePrefix + repoInfo.RemoteName.Name())
+ 			if err != nil {
+ 				return nil, err
+ 			}
+ 		}
+ 
+-		repoInfo.CanonicalName, err = reference.WithName("docker.io/" + repoInfo.RemoteName.Name())
++		repoInfo.CanonicalName, err = reference.WithName(IndexName + "/" + repoInfo.RemoteName.Name())
++		if err != nil {
++			return nil, err
++		}
++		repoInfo.LocalName, err = reference.WithName(repoInfo.Index.Name + "/" + normalizedName.Name())
+ 		if err != nil {
+ 			return nil, err
+ 		}
+@@ -357,13 +449,22 @@ func ParseSearchIndexInfo(reposName string) (*registrytypes.IndexInfo, error) {
+ // NormalizeLocalName transforms a repository name into a normalized LocalName
+ // Passes through the name without transformation on error (image id, etc)
+ // It does not use the repository info because we don't want to load
+-// the repository index and do request over the network.
+-func NormalizeLocalName(name reference.Named) reference.Named {
++// the repository index and do request over the network. Returned reference
++// will always be fully qualified unless an error occurs or there's no
++// default registry.
++func NormalizeLocalName(name reference.Named, keepUnqualified bool) reference.Named {
+ 	indexName, remoteName, err := loadRepositoryName(name)
+ 	if err != nil {
+ 		return name
+ 	}
+ 
++	fullyQualified := true
++	if indexName == "" {
++		indexName = IndexServerName()
++		fullyQualified = false
++	}
++	fullyQualify := !keepUnqualified || fullyQualified
++
+ 	var officialIndex bool
+ 	// Return any configured index info, first.
+ 	if index, ok := emptyServiceConfig.IndexConfigs[indexName]; ok {
+@@ -371,12 +472,23 @@ func NormalizeLocalName(name reference.Named) reference.Named {
+ 	}
+ 
+ 	if officialIndex {
+-		localName, err := normalizeLibraryRepoName(remoteName)
++		localName := remoteName
++		if fullyQualify {
++			localName, err = reference.WithName(IndexName + "/" + remoteName.Name())
++			if err != nil {
++				return name
++			}
++		}
++		localName, err = normalizeLibraryRepoName(localName)
+ 		if err != nil {
+ 			return name
+ 		}
+ 		return localName
+ 	}
++
++	if !fullyQualify {
++		indexName = ""
++	}
+ 	localName, err := localNameFromRemote(indexName, remoteName)
+ 	if err != nil {
+ 		return name
+@@ -387,24 +499,34 @@ func NormalizeLocalName(name reference.Named) reference.Named {
+ // normalizeLibraryRepoName removes the library prefix from
+ // the repository name for official repos.
+ func normalizeLibraryRepoName(name reference.Named) (reference.Named, error) {
+-	if strings.HasPrefix(name.Name(), "library/") {
+-		// If pull "library/foo", it's stored locally under "foo"
+-		return reference.WithName(strings.SplitN(name.Name(), "/", 2)[1])
++	indexName, remoteName, err := splitReposName(name, false)
++	if err != nil {
++		return nil, err
+ 	}
+-	return name, nil
++	remoteName, err = reference.WithName(strings.TrimPrefix(remoteName.Name(), OfficialReposNamePrefix))
++	if err != nil {
++		return nil, err
++	}
++	if indexName == "" {
++		return remoteName, nil
++	}
++	return reference.WithName(indexName + "/" + remoteName.Name())
+ }
+ 
+ // localNameFromRemote combines the index name and the repo remote name
+ // to generate a repo local name.
+ func localNameFromRemote(indexName string, remoteName reference.Named) (reference.Named, error) {
++	if indexName == "" {
++		return remoteName, nil
++	}
+ 	return reference.WithName(indexName + "/" + remoteName.Name())
+ }
+ 
+ // NormalizeLocalReference transforms a reference to use a normalized LocalName
+ // for the name poriton. Passes through the reference without transformation on
+ // error.
+-func NormalizeLocalReference(ref reference.Named) reference.Named {
+-	localName := NormalizeLocalName(ref)
++func NormalizeLocalReference(ref reference.Named, keepUnqualified bool) reference.Named {
++	localName := NormalizeLocalName(ref, keepUnqualified)
+ 	if tagged, isTagged := ref.(reference.Tagged); isTagged {
+ 		newRef, err := reference.WithTag(localName, tagged.Tag())
+ 		if err != nil {
+@@ -420,3 +542,54 @@ func NormalizeLocalReference(ref reference.Named) reference.Named {
+ 	}
+ 	return localName
+ }
++
++// FullyQualifyReferenceWith joins given index name with reference. If the
++// reference is already qualified or resulting reference is invalid, an error
++// will be returned.
++func FullyQualifyReferenceWith(indexName string, ref reference.Named) (reference.Named, error) {
++	if indexName == "" {
++		return nil, fmt.Errorf("index name cannot be empty")
++	}
++	fqn, err := reference.WithName(indexName + "/" + ref.Name())
++	if err != nil {
++		return nil, err
++	}
++	fqn = NormalizeLocalName(fqn, false)
++	if tagged, isTagged := ref.(reference.Tagged); isTagged {
++		newRef, err := reference.WithTag(fqn, tagged.Tag())
++		if err != nil {
++			return nil, err
++		}
++		return newRef, nil
++	} else if digested, isDigested := ref.(reference.Digested); isDigested {
++		newRef, err := reference.WithDigest(fqn, digested.Digest())
++		if err != nil {
++			return nil, err
++		}
++		return newRef, nil
++	}
++	return fqn, nil
++}
++
++// SubstituteReferenceName creates a new image reference from given ref with
++// its *name* part substituted for reposName.
++func SubstituteReferenceName(ref reference.Named, reposName string) (newRef reference.Named, err error) {
++	reposNameRef, err := reference.WithName(reposName)
++	if err != nil {
++		return nil, err
++	}
++	if tagged, isTagged := ref.(reference.Tagged); isTagged {
++		newRef, err = reference.WithTag(reposNameRef, tagged.Tag())
++		if err != nil {
++			return nil, err
++		}
++	} else if digested, isDigested := ref.(reference.Digested); isDigested {
++		newRef, err = reference.WithDigest(reposNameRef, digested.Digest())
++		if err != nil {
++			return nil, err
++		}
++	} else {
++		newRef = reposNameRef
++	}
++	return
++}
+diff --git a/registry/registry_mock_test.go b/registry/registry_mock_test.go
+index f45de5c..119bb7c 100644
+--- a/registry/registry_mock_test.go
++++ b/registry/registry_mock_test.go
+@@ -356,7 +356,7 @@ func handlerGetDeleteTags(w http.ResponseWriter, r *http.Request) {
+ 		apiError(w, "Could not parse repository", 400)
+ 		return
+ 	}
+-	repositoryName = NormalizeLocalName(repositoryName)
++	repositoryName = NormalizeLocalName(repositoryName, true)
+ 	tags, exists := testRepositories[repositoryName.String()]
+ 	if !exists {
+ 		apiError(w, "Repository not found", 404)
+@@ -380,7 +380,7 @@ func handlerGetTag(w http.ResponseWriter, r *http.Request) {
+ 		apiError(w, "Could not parse repository", 400)
+ 		return
+ 	}
+-	repositoryName = NormalizeLocalName(repositoryName)
++	repositoryName = NormalizeLocalName(repositoryName, true)
+ 	tagName := vars["tag"]
+ 	tags, exists := testRepositories[repositoryName.String()]
+ 	if !exists {
+@@ -405,7 +405,7 @@ func handlerPutTag(w http.ResponseWriter, r *http.Request) {
+ 		apiError(w, "Could not parse repository", 400)
+ 		return
+ 	}
+-	repositoryName = NormalizeLocalName(repositoryName)
++	repositoryName = NormalizeLocalName(repositoryName, true)
+ 	tagName := vars["tag"]
+ 	tags, exists := testRepositories[repositoryName.String()]
+ 	if !exists {
+diff --git a/registry/registry_test.go b/registry/registry_test.go
+index 7e35244..b21d6c1 100644
+--- a/registry/registry_test.go
++++ b/registry/registry_test.go
+@@ -370,7 +370,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("fooo/bar"),
+-			LocalName:     withName("fooo/bar"),
++			LocalName:     withName("docker.io/fooo/bar"),
+ 			CanonicalName: withName("docker.io/fooo/bar"),
+ 			Official:      false,
+ 		},
+@@ -380,7 +380,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("library/ubuntu"),
+-			LocalName:     withName("ubuntu"),
++			LocalName:     withName("docker.io/ubuntu"),
+ 			CanonicalName: withName("docker.io/library/ubuntu"),
+ 			Official:      true,
+ 		},
+@@ -390,7 +390,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("nonlibrary/ubuntu"),
+-			LocalName:     withName("nonlibrary/ubuntu"),
++			LocalName:     withName("docker.io/nonlibrary/ubuntu"),
+ 			CanonicalName: withName("docker.io/nonlibrary/ubuntu"),
+ 			Official:      false,
+ 		},
+@@ -400,7 +400,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("library/ubuntu"),
+-			LocalName:     withName("ubuntu"),
++			LocalName:     withName("docker.io/ubuntu"),
+ 			CanonicalName: withName("docker.io/library/ubuntu"),
+ 			Official:      true,
+ 		},
+@@ -410,7 +410,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("other/library"),
+-			LocalName:     withName("other/library"),
++			LocalName:     withName("docker.io/other/library"),
+ 			CanonicalName: withName("docker.io/other/library"),
+ 			Official:      false,
+ 		},
+@@ -520,7 +520,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("public/moonbase"),
+-			LocalName:     withName("public/moonbase"),
++			LocalName:     withName("docker.io/public/moonbase"),
+ 			CanonicalName: withName("docker.io/public/moonbase"),
+ 			Official:      false,
+ 		},
+@@ -530,7 +530,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("public/moonbase"),
+-			LocalName:     withName("public/moonbase"),
++			LocalName:     withName("docker.io/public/moonbase"),
+ 			CanonicalName: withName("docker.io/public/moonbase"),
+ 			Official:      false,
+ 		},
+@@ -540,7 +540,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("library/ubuntu-12.04-base"),
+-			LocalName:     withName("ubuntu-12.04-base"),
++			LocalName:     withName("docker.io/ubuntu-12.04-base"),
+ 			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+ 			Official:      true,
+ 		},
+@@ -550,7 +550,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("library/ubuntu-12.04-base"),
+-			LocalName:     withName("ubuntu-12.04-base"),
++			LocalName:     withName("docker.io/ubuntu-12.04-base"),
+ 			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+ 			Official:      true,
+ 		},
+@@ -560,7 +560,7 @@ func TestParseRepositoryInfo(t *testing.T) {
+ 				Official: true,
+ 			},
+ 			RemoteName:    withName("library/ubuntu-12.04-base"),
+-			LocalName:     withName("ubuntu-12.04-base"),
++			LocalName:     withName("docker.io/ubuntu-12.04-base"),
+ 			CanonicalName: withName("docker.io/library/ubuntu-12.04-base"),
+ 			Official:      true,
+ 		},
+diff --git a/registry/service.go b/registry/service.go
+index b826f11..6eab776 100644
+--- a/registry/service.go
++++ b/registry/service.go
+@@ -2,6 +2,7 @@ package registry
+ 
+ import (
+ 	"crypto/tls"
++	"fmt"
+ 	"net/http"
+ 	"net/url"
+ 	"strings"
+@@ -33,7 +34,10 @@ func (s *Service) Auth(authConfig *types.AuthConfig) (string, error) {
+ 	addr := authConfig.ServerAddress
+ 	if addr == "" {
+ 		// Use the official registry address if not specified.
+-		addr = IndexServer
++		addr = IndexServerAddress()
++	}
++	if addr == "" {
++		return "", fmt.Errorf("No configured registry to authenticate to.")
+ 	}
+ 	index, err := s.ResolveIndex(addr)
+ 	if err != nil {
+@@ -98,7 +102,7 @@ func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[
+ 
+ 	if index.Official {
+ 		localName := remoteName
+-		if strings.HasPrefix(localName, "library/") {
++		if strings.HasPrefix(localName, OfficialReposNamePrefix) {
+ 			// If pull "library/foo", it's stored locally under "foo"
+ 			localName = strings.SplitN(localName, "/", 2)[1]
+ 		}
+@@ -177,15 +181,18 @@ func (s *Service) lookupEndpoints(repoName reference.Named) (endpoints []APIEndp
+ 		return nil, err
+ 	}
+ 
+-	if V2Only {
+-		return endpoints, nil
++	if !V2Only {
++		legacyEndpoints, err := s.lookupV1Endpoints(repoName)
++		if err != nil {
++			return nil, err
++		}
++		endpoints = append(endpoints, legacyEndpoints...)
+ 	}
+ 
+-	legacyEndpoints, err := s.lookupV1Endpoints(repoName)
+-	if err != nil {
+-		return nil, err
++	filtered := filterBlockedEndpoints(endpoints)
++	if len(filtered) == 0 && len(endpoints) > 0 {
++		return nil, fmt.Errorf("All endpoints blocked.")
+ 	}
+-	endpoints = append(endpoints, legacyEndpoints...)
+ 
+-	return endpoints, nil
++	return filtered, nil
+ }
+diff --git a/registry/session.go b/registry/session.go
+index 102263b..34eecc4 100644
+--- a/registry/session.go
++++ b/registry/session.go
+@@ -177,6 +177,10 @@ func NewSession(client *http.Client, authConfig *types.AuthConfig, endpoint *End
+ 		}
+ 	}
+ 
++	if endpoint != nil && isEndpointURLBlocked(endpoint.URL.Host) {
++		return nil, fmt.Errorf("Index %q is blocked.", endpoint.URL.Host)
++	}
++
+ 	r = &Session{
+ 		authConfig:    authConfig,
+ 		client:        client,
+@@ -321,6 +325,31 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
+ 	return res.Body, nil
+ }
+ 
++func isEndpointURLBlocked(endpoint string) bool {
++	if parsedURL, err := url.Parse(endpoint); err == nil {
++		if !IsIndexBlocked(parsedURL.Host) {
++			return false
++		}
++	}
++	return true
++}
++
++func isEndpointBlocked(endpoint APIEndpoint) bool {
++	return isEndpointURLBlocked(endpoint.URL)
++}
++
++func filterBlockedEndpoints(endpoints []APIEndpoint) []APIEndpoint {
++	res := []APIEndpoint{}
++	for _, endpoint := range endpoints {
++		if !isEndpointBlocked(endpoint) {
++			res = append(res, endpoint)
++		} else {
++			logrus.Infof("Skipping blocked endpoint %q", endpoint.URL)
++		}
++	}
++	return res
++}
++
+ // GetRemoteTag retrieves the tag named in the askedTag argument from the given
+ // repository. It queries each of the registries supplied in the registries
+ // argument, and returns data from the first one that answers the query
+@@ -328,12 +357,16 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, imgSize int64) (io
+ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Named, askedTag string) (string, error) {
+ 	repository := repositoryRef.Name()
+ 
+-	if strings.Count(repository, "/") == 0 {
+-		// This will be removed once the registry supports auto-resolution on
+-		// the "library" namespace
+-		repository = "library/" + repository
+-	}
+ 	for _, host := range registries {
++		if host == IndexServer && strings.Count(repository, "/") == 0 {
++			// This will be removed once the registry supports auto-resolution on
++			// the "library" namespace
++			repository = OfficialReposNamePrefix + repository
++		}
++		if isEndpointURLBlocked(host) {
++			logrus.Errorf("Cannot query blocked registry at %s for remote tags.", host)
++			continue
++		}
+ 		endpoint := fmt.Sprintf("%srepositories/%s/tags/%s", host, repository, askedTag)
+ 		res, err := r.client.Get(endpoint)
+ 		if err != nil {
+@@ -366,12 +399,16 @@ func (r *Session) GetRemoteTag(registries []string, repositoryRef reference.Name
+ func (r *Session) GetRemoteTags(registries []string, repositoryRef reference.Named) (map[string]string, error) {
+ 	repository := repositoryRef.Name()
+ 
+-	if strings.Count(repository, "/") == 0 {
+-		// This will be removed once the registry supports auto-resolution on
+-		// the "library" namespace
+-		repository = "library/" + repository
+-	}
+ 	for _, host := range registries {
++		if host == IndexServer && strings.Count(repository, "/") == 0 {
++			// This will be removed once the registry supports auto-resolution on
++			// the "library" namespace
++			repository = OfficialReposNamePrefix + repository
++		}
++		if isEndpointURLBlocked(host) {
++			logrus.Errorf("Cannot query blocked registry at %s for remote tags.", host)
++			continue
++		}
+ 		endpoint := fmt.Sprintf("%srepositories/%s/tags", host, repository)
+ 		res, err := r.client.Get(endpoint)
+ 		if err != nil {
+diff --git a/tag/store.go b/tag/store.go
+index f09db74..dc33e2e 100644
+--- a/tag/store.go
++++ b/tag/store.go
+@@ -10,9 +10,11 @@ import (
+ 	"sort"
+ 	"sync"
+ 
++	"github.com/Sirupsen/logrus"
+ 	"github.com/docker/distribution/digest"
+ 	"github.com/docker/distribution/reference"
+ 	"github.com/docker/docker/image"
++	"github.com/docker/docker/registry"
+ )
+ 
+ // DefaultTag defines the default tag used when performing images related actions and no tag string is specified
+@@ -56,6 +58,11 @@ type store struct {
+ // including the repository name.
+ type repository map[string]image.ID
+ 
++type namedRepository struct {
++	name       string
++	repository repository
++}
++
+ type lexicalRefs []reference.Named
+ 
+ func (a lexicalRefs) Len() int           { return len(a) }
+@@ -171,26 +178,27 @@ func (store *store) Delete(ref reference.Named) (bool, error) {
+ 	store.mu.Lock()
+ 	defer store.mu.Unlock()
+ 
+-	repoName := ref.Name()
+-
+-	repository, exists := store.Repositories[repoName]
+-	if !exists {
+-		return false, ErrDoesNotExist
+-	}
+-
+-	refStr := ref.String()
+-	if id, exists := repository[refStr]; exists {
+-		delete(repository, refStr)
+-		if len(repository) == 0 {
+-			delete(store.Repositories, repoName)
++	matching := store.getMatchingRepositoryList(ref)
++	for _, namedRepo := range matching {
++		tmpRef, err := registry.SubstituteReferenceName(ref, namedRepo.name)
++		if err != nil {
++			logrus.Debugf("failed to substitute name %q in %q for %q", ref.Name, ref.String(), namedRepo.name)
++			continue
+ 		}
+-		if store.referencesByIDCache[id] != nil {
+-			delete(store.referencesByIDCache[id], refStr)
+-			if len(store.referencesByIDCache[id]) == 0 {
+-				delete(store.referencesByIDCache, id)
++		refStr := tmpRef.String()
++		if id, exists := namedRepo.repository[refStr]; exists {
++			delete(namedRepo.repository, refStr)
++			if len(namedRepo.repository) == 0 {
++				delete(store.Repositories, namedRepo.name)
++			}
++			if store.referencesByIDCache[id] != nil {
++				delete(store.referencesByIDCache[id], refStr)
++				if len(store.referencesByIDCache[id]) == 0 {
++					delete(store.referencesByIDCache, id)
++				}
+ 			}
++			return true, store.save()
+ 		}
+-		return true, store.save()
+ 	}
+ 
+ 	return false, ErrDoesNotExist
+@@ -203,17 +211,19 @@ func (store *store) Get(ref reference.Named) (image.ID, error) {
+ 	store.mu.RLock()
+ 	defer store.mu.RUnlock()
+ 
+-	repository, exists := store.Repositories[ref.Name()]
+-	if !exists || repository == nil {
+-		return "", ErrDoesNotExist
+-	}
+-
+-	id, exists := repository[ref.String()]
+-	if !exists {
+-		return "", ErrDoesNotExist
++	matching := store.getMatchingRepositoryList(ref)
++	for _, namedRepo := range matching {
++		tmpRef, err := registry.SubstituteReferenceName(ref, namedRepo.name)
++		if err != nil {
++			logrus.Debugf("failed to substitute name %q in %q for %q", ref.Name, ref.String(), namedRepo.name)
++			continue
++		}
++		if revision, exists := namedRepo.repository[tmpRef.String()]; exists {
++			return revision, nil
++		}
+ 	}
+ 
+-	return id, nil
++	return "", ErrDoesNotExist
+ }
+ 
+ // References returns a slice of references to the given image ID. The slice
+@@ -243,13 +253,15 @@ func (store *store) ReferencesByName(ref reference.Named) []Association {
+ 	store.mu.RLock()
+ 	defer store.mu.RUnlock()
+ 
+-	repository, exists := store.Repositories[ref.Name()]
+-	if !exists {
++	matching := store.getMatchingRepositoryList(ref)
++	if len(matching) == 0 {
+ 		return nil
+ 	}
++	// the first matching is the best match
++	namedRepo := matching[0]
+ 
+ 	var associations []Association
+-	for refStr, refID := range repository {
++	for refStr, refID := range namedRepo.repository {
+ 		ref, err := reference.ParseNamed(refStr)
+ 		if err != nil {
+ 			// Should never happen
+@@ -313,3 +325,56 @@ func (store *store) reload() error {
+ 
+ 	return nil
+ }
++
++// getMatchingRepositoryList returns a list of local repositories matching
++// given repository name. Results will be sorted in following way:
++//   1. precise match
++//   2. precise match after normalization
++//   3. match after prefixing with default registry name and normalization
++// *Default registry* here means any registry in registry.RegistryList.
++func (store *store) getMatchingRepositoryList(ref reference.Named) (result []namedRepository) {
++	repoMap := map[string]struct{}{}
++	addResult := func(name string, repo repository) bool {
++		if _, exists := repoMap[name]; exists {
++			return false
++		}
++		result = append(result, namedRepository{
++			name:       name,
++			repository: repo,
++		})
++		repoMap[name] = struct{}{}
++		return true
++	}
++
++	// precise match
++	repoName := ref.Name()
++	if r, exists := store.Repositories[repoName]; exists {
++		addResult(repoName, r)
++	}
++
++	// precise match after normalization
++	for _, keepUnqualified := range []bool{false, true} {
++		normalized := registry.NormalizeLocalName(ref, keepUnqualified).Name()
++		if r, exists := store.Repositories[normalized]; exists {
++			addResult(normalized, r)
++		}
++	}
++
++	if !registry.IsReferenceFullyQualified(ref) {
++		// match after prefixing with default registry and normalization
++		for i := 0; i < len(registry.RegistryList); i++ {
++			if i < 1 {
++				continue // the first registry has been already processed
++			}
++			fqRef, err := registry.FullyQualifyReferenceWith(registry.RegistryList[i], ref)
++			if err != nil {
++				continue
++			}
++			if r, exists := store.Repositories[fqRef.Name()]; exists {
++				addResult(fqRef.Name(), r)
++			}
++		}
++	}
++
++	return
++}
+-- 
+2.5.0
+

--- a/patch/0012-Allow-for-remote-repository-inspection.patch
+++ b/patch/0012-Allow-for-remote-repository-inspection.patch
@@ -1,0 +1,1851 @@
+From 2ca7a07d4ae5ef5ff1030d396df68483ff55f63b Mon Sep 17 00:00:00 2001
+From: Michal Minar <miminar@redhat.com>
+Date: Mon, 11 May 2015 07:45:14 +0200
+Subject: [PATCH 12/13] Allow for remote repository inspection
+
+**Inspect remote images**
+
+Extended server API to allow for inspection of remote images. If a short
+name is given, list of additional registries will be queried until a
+repository is found. This allows for remote inspection without
+downloading image layers.
+
+The URL is following:
+
+    /<apiVersion>/images/<repoName>/json?remote=1
+
+The output is the same json as for local images. However, it excludes
+few attributes specific only to local images:
+
+- GraphDriver
+- VirtualSize
+
+And it adds some additional attributes:
+
+- Digest
+- Tag
+- Registry
+
+**List tags of remote repository**
+
+Extended server API to allow for listing of remote repositories.
+
+The URL is following:
+
+    /<apiVersion>/images/<repoName>/tags?remote=1
+
+If a short name is given, list of additional registries will be queried
+until a repository is found.
+
+Returned is a json in following format:
+
+    { "Name"    : "<repoName>"
+    , "TagList" : [ {"<tag1>" : "<ID1>", "<tag2>" : <ID2>" } ]
+    }
+
+Quirks and TODOs:
+ - By default V1 registry enpoints are queried because they provide tags
+   with associated image IDs. If not available, V2 endpoint will be
+   tried. In such a case the output will lack image IDs though.
+
+Signed-off-by: Michal Minar <miminar@redhat.com>
+---
+ api/server/router/local/image.go            |  82 +++++++++-
+ api/server/router/local/local.go            |   1 +
+ api/types/types.go                          |  35 ++++-
+ daemon/daemon.go                            | 103 +++++++++---
+ distribution/inspect.go                     | 187 ++++++++++++++++++++++
+ distribution/inspect_v1.go                  | 160 +++++++++++++++++++
+ distribution/inspect_v2.go                  | 162 +++++++++++++++++++
+ distribution/list.go                        | 173 ++++++++++++++++++++
+ distribution/list_v1.go                     |  73 +++++++++
+ distribution/list_v2.go                     |  55 +++++++
+ image/v1/imagev1.go                         |  22 ++-
+ integration-cli/docker_api_inspect_test.go  | 220 ++++++++++++++++++++++++++
+ integration-cli/docker_api_tag_list_test.go | 234 ++++++++++++++++++++++++++++
+ integration-cli/docker_utils.go             |  73 ++++++++-
+ 14 files changed, 1549 insertions(+), 31 deletions(-)
+ create mode 100644 distribution/inspect.go
+ create mode 100644 distribution/inspect_v1.go
+ create mode 100644 distribution/inspect_v2.go
+ create mode 100644 distribution/list.go
+ create mode 100644 distribution/list_v1.go
+ create mode 100644 distribution/list_v2.go
+ create mode 100644 integration-cli/docker_api_tag_list_test.go
+
+diff --git a/api/server/router/local/image.go b/api/server/router/local/image.go
+index 32e0da9..2af297a 100644
+--- a/api/server/router/local/image.go
++++ b/api/server/router/local/image.go
+@@ -300,7 +300,42 @@ func (s *router) deleteImages(ctx context.Context, w http.ResponseWriter, r *htt
+ }
+ 
+ func (s *router) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+-	imageInspect, err := s.daemon.LookupImage(vars["name"])
++	if vars == nil {
++		return fmt.Errorf("Missing parameter")
++	}
++
++	name := vars["name"]
++
++	if httputils.BoolValue(r, "remote") {
++		authEncoded := r.Header.Get("X-Registry-Auth")
++		authConfig := &types.AuthConfig{}
++		if authEncoded != "" {
++			authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
++			if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
++				// for a pull it is not an error if no auth was given
++				// to increase compatibility with the existing api it is defaulting to be empty
++				authConfig = &types.AuthConfig{}
++			}
++		}
++
++		ref, err := reference.ParseNamed(name)
++		if err != nil {
++			return err
++		}
++		metaHeaders := map[string][]string{}
++		for k, v := range r.Header {
++			if strings.HasPrefix(k, "X-Meta-") {
++				metaHeaders[k] = v
++			}
++		}
++		imageInspect, err := s.daemon.LookupRemote(ref, metaHeaders, authConfig)
++		if err != nil {
++			return err
++		}
++		return httputils.WriteJSON(w, http.StatusOK, imageInspect)
++	}
++
++	imageInspect, err := s.daemon.LookupImage(name)
+ 	if err != nil {
+ 		return err
+ 	}
+@@ -308,6 +343,51 @@ func (s *router) getImagesByName(ctx context.Context, w http.ResponseWriter, r *
+ 	return httputils.WriteJSON(w, http.StatusOK, imageInspect)
+ }
+ 
++func (s *router) getImagesTags(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
++	name := vars["name"]
++	authEncoded := r.Header.Get("X-Registry-Auth")
++	authConfig := &types.AuthConfig{}
++	if authEncoded != "" {
++		authJSON := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
++		if err := json.NewDecoder(authJSON).Decode(authConfig); err != nil {
++			// for a pull it is not an error if no auth was given
++			// to increase compatibility with the existing api it is defaulting to be empty
++			authConfig = &types.AuthConfig{}
++		}
++	}
++
++	var tagList *types.RepositoryTagList
++	reposName, err := reference.WithName(name)
++	if err != nil {
++		return nil
++	}
++
++	if !httputils.BoolValue(r, "remote") {
++		tagList, err = s.daemon.ListLocalTags(reposName)
++		if err != nil {
++			logrus.Warnf("failed to get local tags for %q: %v", name, err)
++		}
++	}
++
++	if tagList == nil || err != nil {
++		metaHeaders := map[string][]string{}
++		for k, v := range r.Header {
++			if strings.HasPrefix(k, "X-Meta-") {
++				metaHeaders[k] = v
++			}
++		}
++		tagList, err = s.daemon.ListRemoteTags(reposName, metaHeaders, authConfig)
++		if err != nil {
++			logrus.Warnf("failed to get remote tags for %q: %v", name, err)
++		}
++	}
++	if err != nil {
++		return err
++	}
++
++	return httputils.WriteJSON(w, http.StatusOK, tagList)
++}
++
+ func (s *router) postBuild(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+ 	var (
+ 		authConfigs        = map[string]types.AuthConfig{}
+diff --git a/api/server/router/local/local.go b/api/server/router/local/local.go
+index 2a3106a..9ce3923 100644
+--- a/api/server/router/local/local.go
++++ b/api/server/router/local/local.go
+@@ -95,6 +95,7 @@ func (r *router) initRoutes() {
+ 		NewGetRoute("/images/{name:.*}/get", r.getImagesGet),
+ 		NewGetRoute("/images/{name:.*}/history", r.getImagesHistory),
+ 		NewGetRoute("/images/{name:.*}/json", r.getImagesByName),
++		NewGetRoute("/images/{name:.*}/tags", r.getImagesTags),
+ 		// POST
+ 		NewPostRoute("/commit", r.postCommit),
+ 		NewPostRoute("/build", r.postBuild),
+diff --git a/api/types/types.go b/api/types/types.go
+index 3982051..0b89500 100644
+--- a/api/types/types.go
++++ b/api/types/types.go
+@@ -93,9 +93,9 @@ type GraphDriverData struct {
+ 	Data map[string]string
+ }
+ 
+-// ImageInspect contains response of Remote API:
++// ImageInspectBase contains response of Remote API:
+ // GET "/images/{name:.*}/json"
+-type ImageInspect struct {
++type ImageInspectBase struct {
+ 	ID              string `json:"Id"`
+ 	RepoTags        []string
+ 	RepoDigests     []string
+@@ -110,8 +110,21 @@ type ImageInspect struct {
+ 	Architecture    string
+ 	Os              string
+ 	Size            int64
+-	VirtualSize     int64
+-	GraphDriver     GraphDriverData
++}
++
++// ImageInspect contains response of Remote API:
++// GET "/images/{name:.*}/json"
++type ImageInspect struct {
++	ImageInspectBase
++	VirtualSize int64
++	GraphDriver GraphDriverData
++}
++
++// RemoteImageInspect contains response of RemoteAPI:
++// GET "/images/{name:.*}/json?remote=1"
++type RemoteImageInspect struct {
++	ImageInspectBase
++	Registry string
+ }
+ 
+ // Port stores open ports info of container
+@@ -343,6 +356,20 @@ type MountPoint struct {
+ 	Propagation string
+ }
+ 
++// RepositoryTag stores an metadata for a image's tag.
++type RepositoryTag struct {
++	Tag     string
++	ImageID string
++}
++
++// RepositoryTagList contains the response for the remote API:
++// GET "/images/{name:.*}/tags"
++type RepositoryTagList struct {
++	// Fully qualified repository name
++	Name    string
++	TagList []*RepositoryTag
++}
++
+ // Volume represents the configuration of a volume for the remote API
+ type Volume struct {
+ 	Name       string // Name is the name of the volume
+diff --git a/daemon/daemon.go b/daemon/daemon.go
+index ce2fa73..924a9e9 100644
+--- a/daemon/daemon.go
++++ b/daemon/daemon.go
+@@ -13,6 +13,7 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 	"runtime"
++	"sort"
+ 	"strings"
+ 	"sync"
+ 	"time"
+@@ -132,6 +133,12 @@ func (c *contStore) List() []*container.Container {
+ 	return *containers
+ }
+ 
++type byTagName []*types.RepositoryTag
++
++func (r byTagName) Len() int           { return len(r) }
++func (r byTagName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
++func (r byTagName) Less(i, j int) bool { return r[i].Tag < r[j].Tag }
++
+ // Daemon holds information about the Docker daemon.
+ type Daemon struct {
+ 	ID                        string
+@@ -1187,30 +1194,44 @@ func (daemon *Daemon) LookupImage(name string) (*types.ImageInspect, error) {
+ 	}
+ 
+ 	imageInspect := &types.ImageInspect{
+-		ID:              img.ID().String(),
+-		RepoTags:        repoTags,
+-		RepoDigests:     repoDigests,
+-		Parent:          img.Parent.String(),
+-		Comment:         img.Comment,
+-		Created:         img.Created.Format(time.RFC3339Nano),
+-		Container:       img.Container,
+-		ContainerConfig: &img.ContainerConfig,
+-		DockerVersion:   img.DockerVersion,
+-		Author:          img.Author,
+-		Config:          img.Config,
+-		Architecture:    img.Architecture,
+-		Os:              img.OS,
+-		Size:            size,
+-		VirtualSize:     size, // TODO: field unused, deprecate
+-	}
+-
+-	imageInspect.GraphDriver.Name = daemon.driver.String()
+-
+-	imageInspect.GraphDriver.Data = layerMetadata
++		ImageInspectBase: types.ImageInspectBase{
++			ID:              img.ID().String(),
++			RepoTags:        repoTags,
++			RepoDigests:     repoDigests,
++			Parent:          img.Parent.String(),
++			Comment:         img.Comment,
++			Created:         img.Created.Format(time.RFC3339Nano),
++			Container:       img.Container,
++			ContainerConfig: &img.ContainerConfig,
++			DockerVersion:   img.DockerVersion,
++			Author:          img.Author,
++			Config:          img.Config,
++			Architecture:    img.Architecture,
++			Os:              img.OS,
++			Size:            size,
++		},
++		VirtualSize: size, // TODO: field unused, deprecate
++		GraphDriver: types.GraphDriverData{
++			Name: daemon.driver.String(),
++			Data: layerMetadata,
++		},
++	}
+ 
+ 	return imageInspect, nil
+ }
+ 
++// LookupRemote looks up an image in remote repository.
++func (daemon *Daemon) LookupRemote(ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig) (*types.RemoteImageInspect, error) {
++	inspectConfig := &distribution.InspectConfig{
++		MetaHeaders:     metaHeaders,
++		AuthConfig:      authConfig,
++		RegistryService: daemon.RegistryService,
++		MetadataStore:   daemon.distributionMetadataStore,
++	}
++
++	return distribution.Inspect(ref, inspectConfig)
++}
++
+ // LoadImage uploads a set of images into the repository. This is the
+ // complement of ImageExport.  The input stream is an uncompressed tar
+ // ball containing images and metadata.
+@@ -1333,6 +1354,48 @@ func (daemon *Daemon) GetImage(refOrID string) (*image.Image, error) {
+ 	return daemon.imageStore.Get(imgID)
+ }
+ 
++// ListLocalTags returns a tag list for given local repository.
++func (daemon *Daemon) ListLocalTags(reposName reference.Named) (*types.RepositoryTagList, error) {
++	var tagList *types.RepositoryTagList
++
++	if err := registry.ValidateRepositoryName(reposName); err != nil {
++		return nil, err
++	}
++
++	associations := daemon.tagStore.ReferencesByName(reposName)
++	if len(associations) == 0 {
++		return nil, ErrImageDoesNotExist{reposName.String()}
++	}
++
++	tagList = &types.RepositoryTagList{
++		Name:    associations[0].Ref.Name(),
++		TagList: make([]*types.RepositoryTag, 0, len(associations)),
++	}
++
++	for _, assoc := range associations {
++		if tagged, isTagged := assoc.Ref.(reference.Tagged); isTagged {
++			tagList.TagList = append(tagList.TagList, &types.RepositoryTag{
++				Tag:     tagged.Tag(),
++				ImageID: assoc.ImageID.String(),
++			})
++		}
++	}
++
++	sort.Sort(byTagName(tagList.TagList))
++	return tagList, nil
++}
++
++// ListRemoteTags fetches a tag list from remote repository.
++func (daemon *Daemon) ListRemoteTags(ref reference.Named, metaHeaders map[string][]string, authConfig *types.AuthConfig) (*types.RepositoryTagList, error) {
++	config := &distribution.ListRemoteTagsConfig{
++		MetaHeaders:     metaHeaders,
++		AuthConfig:      authConfig,
++		RegistryService: daemon.RegistryService,
++	}
++
++	return distribution.ListRemoteTags(ref, config)
++}
++
+ // GraphDriver returns the currently used driver for processing
+ // container layers.
+ func (daemon *Daemon) GraphDriver() graphdriver.Driver {
+diff --git a/distribution/inspect.go b/distribution/inspect.go
+new file mode 100644
+index 0000000..cdc10bc
+--- /dev/null
++++ b/distribution/inspect.go
+@@ -0,0 +1,187 @@
++package distribution
++
++import (
++	"fmt"
++	"io"
++	"time"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution/digest"
++	"github.com/docker/distribution/reference"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/distribution/metadata"
++	"github.com/docker/docker/image"
++	"github.com/docker/docker/registry"
++)
++
++// InspectConfig allows you to pass transport-related data to Inspect
++// function.
++type InspectConfig struct {
++	// MetaHeaders stores HTTP headers with metadata about the image
++	// (DockerHeaders with prefix X-Meta- in the request).
++	MetaHeaders map[string][]string
++	// AuthConfig holds authentication credentials for authenticating with
++	// the registry.
++	AuthConfig *types.AuthConfig
++	// OutStream is the output writer for showing the status of the pull
++	// operation.
++	OutStream io.Writer
++	// RegistryService is the registry service to use for TLS configuration
++	// and endpoint lookup.
++	RegistryService *registry.Service
++	// MetadataStore is the storage backend for distribution-specific
++	// metadata.
++	MetadataStore metadata.Store
++}
++
++// ManifestFetcher allows to pull image's json without any binary blobs.
++type ManifestFetcher interface {
++	Fetch(ref reference.Named) (imgInspect *types.RemoteImageInspect, fallback bool, err error)
++}
++
++// NewManifestFetcher creates appropriate fetcher instance for given endpoint.
++func newManifestFetcher(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *InspectConfig) (ManifestFetcher, error) {
++	switch endpoint.Version {
++	case registry.APIVersion2:
++		return &v2ManifestFetcher{
++			endpoint: endpoint,
++			config:   config,
++			repoInfo: repoInfo,
++		}, nil
++	case registry.APIVersion1:
++		return &v1ManifestFetcher{
++			endpoint: endpoint,
++			config:   config,
++			repoInfo: repoInfo,
++		}, nil
++	}
++	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
++}
++
++func makeRemoteImageInspect(repoInfo *registry.RepositoryInfo, img *image.Image, tag string, dgst digest.Digest) *types.RemoteImageInspect {
++	var repoTags = make([]string, 0, 1)
++	if tag != "" {
++		tagged, err := reference.WithTag(repoInfo.CanonicalName, tag)
++		if err == nil {
++			repoTags = append(repoTags, tagged.String())
++		}
++	}
++	var repoDigests = make([]string, 0, 1)
++	if err := dgst.Validate(); err == nil {
++		repoDigests = append(repoDigests, dgst.String())
++	}
++	return &types.RemoteImageInspect{
++		ImageInspectBase: types.ImageInspectBase{
++			ID:              img.ID().String(),
++			RepoTags:        repoTags,
++			RepoDigests:     repoDigests,
++			Parent:          img.Parent.String(),
++			Comment:         img.Comment,
++			Created:         img.Created.Format(time.RFC3339Nano),
++			Container:       img.Container,
++			ContainerConfig: &img.ContainerConfig,
++			DockerVersion:   img.DockerVersion,
++			Author:          img.Author,
++			Config:          img.Config,
++			Architecture:    img.Architecture,
++			Os:              img.OS,
++			Size:            img.Size,
++		},
++		Registry: repoInfo.Index.Name,
++	}
++}
++
++// Inspect returns metadata for remote image.
++func Inspect(ref reference.Named, config *InspectConfig) (*types.RemoteImageInspect, error) {
++	var (
++		imageInspect *types.RemoteImageInspect
++		err          error
++	)
++	// Unless the index name is specified, iterate over all registries until
++	// the matching image is found.
++	if registry.IsReferenceFullyQualified(ref) {
++		return fetchManifest(ref, config)
++	}
++	if len(registry.RegistryList) == 0 {
++		return nil, fmt.Errorf("No configured registry to pull from.")
++	}
++	for _, r := range registry.RegistryList {
++		// Prepend the index name to the image name.
++		fqr, _err := registry.FullyQualifyReferenceWith(r, ref)
++		if _err != nil {
++			logrus.Warnf("Failed to fully qualify %q name with %q registry: %v", ref.Name(), r, _err)
++			err = _err
++			continue
++		}
++		// Prepend the index name to the image name.
++		if imageInspect, err = fetchManifest(fqr, config); err == nil {
++			return imageInspect, nil
++		}
++	}
++	return imageInspect, err
++}
++
++func fetchManifest(ref reference.Named, config *InspectConfig) (*types.RemoteImageInspect, error) {
++	// Resolve the Repository name from fqn to RepositoryInfo
++	repoInfo, err := config.RegistryService.ResolveRepository(ref)
++	if err != nil {
++		return nil, err
++	}
++
++	if err := validateRepoName(repoInfo.LocalName.Name()); err != nil {
++		return nil, err
++	}
++
++	endpoints, err := config.RegistryService.LookupPullEndpoints(repoInfo.CanonicalName)
++	if err != nil {
++		return nil, err
++	}
++
++	var (
++		lastErr error
++		// discardNoSupportErrors is used to track whether an endpoint encountered an error of type registry.ErrNoSupport
++		// By default it is false, which means that if a ErrNoSupport error is encountered, it will be saved in lastErr.
++		// As soon as another kind of error is encountered, discardNoSupportErrors is set to true, avoiding the saving of
++		// any subsequent ErrNoSupport errors in lastErr.
++		// It's needed for pull-by-digest on v1 endpoints: if there are only v1 endpoints configured, the error should be
++		// returned and displayed, but if there was a v2 endpoint which supports pull-by-digest, then the last relevant
++		// error is the ones from v2 endpoints not v1.
++		discardNoSupportErrors bool
++		imgInspect             *types.RemoteImageInspect
++	)
++	for _, endpoint := range endpoints {
++		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", repoInfo.CanonicalName, endpoint.URL, endpoint.Version)
++		fallback := false
++
++		fetcher, err := newManifestFetcher(endpoint, repoInfo, config)
++		if err != nil {
++			lastErr = err
++			continue
++		}
++		imgInspect, fallback, err = fetcher.Fetch(ref)
++		if err != nil {
++			if fallback {
++				if _, ok := err.(registry.ErrNoSupport); !ok {
++					// Because we found an error that's not ErrNoSupport, discard all subsequent ErrNoSupport errors.
++					discardNoSupportErrors = true
++					// save the current error
++					lastErr = err
++				} else if !discardNoSupportErrors {
++					// Save the ErrNoSupport error, because it's either the first error or all encountered errors
++					// were also ErrNoSupport errors.
++					lastErr = err
++				}
++				continue
++			}
++			logrus.Debugf("Not continuing with error: %v", err)
++			return nil, err
++		}
++
++		return imgInspect, nil
++	}
++
++	if lastErr == nil {
++		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.Index.Name)
++	}
++	return nil, lastErr
++}
+diff --git a/distribution/inspect_v1.go b/distribution/inspect_v1.go
+new file mode 100644
+index 0000000..ccfc08e
+--- /dev/null
++++ b/distribution/inspect_v1.go
+@@ -0,0 +1,160 @@
++package distribution
++
++import (
++	"encoding/json"
++	"errors"
++	"fmt"
++	"strings"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution/reference"
++	"github.com/docker/distribution/registry/client/transport"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/image"
++	"github.com/docker/docker/image/v1"
++	"github.com/docker/docker/registry"
++	tagpkg "github.com/docker/docker/tag"
++)
++
++type v1ManifestFetcher struct {
++	endpoint registry.APIEndpoint
++	config   *InspectConfig
++	repoInfo *registry.RepositoryInfo
++	session  *registry.Session
++}
++
++func (mf *v1ManifestFetcher) Fetch(ref reference.Named) (imgInspect *types.RemoteImageInspect, fallback bool, err error) {
++	if _, isDigested := ref.(reference.Digested); isDigested {
++		// Allowing fallback, because HTTPS v1 is before HTTP v2
++		return nil, true, registry.ErrNoSupport{errors.New("Cannot pull by digest with v1 registry")}
++	}
++	tag := ""
++	if tagged, isTagged := ref.(reference.Tagged); isTagged {
++		tag = tagged.Tag()
++	}
++	tlsConfig, err := mf.config.RegistryService.TLSConfig(mf.repoInfo.Index.Name)
++	if err != nil {
++		return nil, false, err
++	}
++	// Adds Docker-specific headers as well as user-specified headers (metaHeaders)
++	tr := transport.NewTransport(
++		// TODO(tiborvass): was ReceiveTimeout
++		registry.NewTransport(tlsConfig),
++		registry.DockerHeaders(mf.config.MetaHeaders)...,
++	)
++	client := registry.HTTPClient(tr)
++	v1Endpoint, err := mf.endpoint.ToV1Endpoint(mf.config.MetaHeaders)
++	if err != nil {
++		logrus.Debugf("Could not get v1 endpoint: %v", err)
++		return nil, true, err
++	}
++	mf.session, err = registry.NewSession(client, mf.config.AuthConfig, v1Endpoint)
++	if err != nil {
++		// TODO(dmcgowan): Check if should fallback
++		logrus.Debugf("Fallback from error: %s", err)
++		return nil, true, err
++	}
++	imgInspect, err = mf.fetchWithSession(tag)
++	return
++}
++
++func (mf *v1ManifestFetcher) fetchWithSession(askedTag string) (*types.RemoteImageInspect, error) {
++	repoData, err := mf.session.GetRepositoryData(mf.repoInfo.RemoteName)
++	if err != nil {
++		if strings.Contains(err.Error(), "HTTP code: 404") {
++			return nil, fmt.Errorf("Error: image %s not found", mf.repoInfo.RemoteName)
++		}
++		// Unexpected HTTP error
++		return nil, err
++	}
++
++	logrus.Debugf("Retrieving the tag list from V1 endpoints")
++	tagsList, err := mf.session.GetRemoteTags(repoData.Endpoints, mf.repoInfo.RemoteName)
++	if err != nil {
++		logrus.Errorf("Unable to get remote tags: %s", err)
++		return nil, err
++	}
++	if len(tagsList) < 1 {
++		return nil, fmt.Errorf("No tags available for remote repository %s", mf.repoInfo.CanonicalName)
++	}
++
++	for tag, id := range tagsList {
++		repoData.ImgList[id] = &registry.ImgData{
++			ID:       id,
++			Tag:      tag,
++			Checksum: "",
++		}
++	}
++
++	// If no tag has been specified, choose `latest` if it exists
++	if askedTag == "" {
++		if _, exists := tagsList[tagpkg.DefaultTag]; exists {
++			askedTag = tagpkg.DefaultTag
++		}
++	}
++	if askedTag == "" {
++		// fallback to any tag in the repository
++		for tag := range tagsList {
++			askedTag = tag
++			break
++		}
++	}
++
++	id, exists := tagsList[askedTag]
++	if !exists {
++		return nil, fmt.Errorf("Tag %s not found in repository %s", askedTag, mf.repoInfo.CanonicalName)
++	}
++	img := repoData.ImgList[id]
++
++	var pulledImg *image.Image
++	for _, ep := range mf.repoInfo.Index.Mirrors {
++		if pulledImg, err = mf.pullImageJSON(img.ID, ep, repoData.Tokens); err != nil {
++			// Don't report errors when pulling from mirrors.
++			logrus.Debugf("Error pulling image json of %s:%s, mirror: %s, %s", mf.repoInfo.CanonicalName, img.Tag, ep, err)
++			continue
++		}
++		break
++	}
++	if pulledImg == nil {
++		for _, ep := range repoData.Endpoints {
++			if pulledImg, err = mf.pullImageJSON(img.ID, ep, repoData.Tokens); err != nil {
++				// It's not ideal that only the last error is returned, it would be better to concatenate the errors.
++				logrus.Infof("Error pulling image json of %s:%s, endpoint: %s, %v", mf.repoInfo.CanonicalName, img.Tag, ep, err)
++				continue
++			}
++			break
++		}
++	}
++	if err != nil {
++		return nil, fmt.Errorf("Error pulling image (%s) from %s, %v", img.Tag, mf.repoInfo.CanonicalName, err)
++	}
++	if pulledImg == nil {
++		return nil, fmt.Errorf("No such image %s:%s", mf.repoInfo.CanonicalName, askedTag)
++	}
++
++	return makeRemoteImageInspect(mf.repoInfo, pulledImg, askedTag, ""), nil
++}
++
++func (mf *v1ManifestFetcher) pullImageJSON(imgID, endpoint string, token []string) (*image.Image, error) {
++	imgJSON, _, err := mf.session.GetRemoteImageJSON(imgID, endpoint)
++	if err != nil {
++		return nil, err
++	}
++	h, err := v1.HistoryFromConfig(imgJSON, false)
++	if err != nil {
++		return nil, err
++	}
++	configRaw, err := v1.MakeRawConfigFromV1Config(imgJSON, image.NewRootFS(), []image.History{h})
++	if err != nil {
++		return nil, err
++	}
++	config, err := json.Marshal(configRaw)
++	if err != nil {
++		return nil, err
++	}
++	img, err := image.NewFromJSON(config)
++	if err != nil {
++		return nil, err
++	}
++	return img, nil
++}
+diff --git a/distribution/inspect_v2.go b/distribution/inspect_v2.go
+new file mode 100644
+index 0000000..e7a5880
+--- /dev/null
++++ b/distribution/inspect_v2.go
+@@ -0,0 +1,162 @@
++package distribution
++
++import (
++	"encoding/json"
++	"fmt"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution"
++	"github.com/docker/distribution/digest"
++	"github.com/docker/distribution/manifest/schema1"
++	"github.com/docker/distribution/reference"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/image"
++	"github.com/docker/docker/image/v1"
++	"github.com/docker/docker/registry"
++	tagpkg "github.com/docker/docker/tag"
++	"golang.org/x/net/context"
++)
++
++type v2ManifestFetcher struct {
++	endpoint registry.APIEndpoint
++	config   *InspectConfig
++	repoInfo *registry.RepositoryInfo
++	repo     distribution.Repository
++}
++
++func (mf *v2ManifestFetcher) Fetch(ref reference.Named) (imgInspect *types.RemoteImageInspect, fallback bool, err error) {
++	mf.repo, err = NewV2Repository(mf.repoInfo, mf.endpoint, mf.config.MetaHeaders, mf.config.AuthConfig)
++	if err != nil {
++		logrus.Debugf("Error getting v2 registry: %v", err)
++		return nil, true, err
++	}
++
++	imgInspect, err = mf.fetchWithRepository(ref)
++	if err != nil && registry.ContinueOnError(err) {
++		logrus.Debugf("Error trying v2 registry: %v", err)
++		fallback = true
++	}
++	return
++}
++
++func (mf *v2ManifestFetcher) fetchWithRepository(ref reference.Named) (*types.RemoteImageInspect, error) {
++	var (
++		exists             bool
++		dgst               digest.Digest
++		err                error
++		img                *image.Image
++		unverifiedManifest *schema1.SignedManifest
++		tag                string
++		tagOrDigest        string
++	)
++
++	manSvc, err := mf.repo.Manifests(context.Background())
++	if err != nil {
++		return nil, err
++	}
++	if digested, isDigested := ref.(reference.Digested); isDigested {
++		exists, err = manSvc.Exists(digested.Digest())
++		if err == nil && !exists {
++			return nil, fmt.Errorf("Digest %q does not exist in remote repository %s", digested.Digest().String(), mf.repoInfo.CanonicalName.Name())
++		}
++		if exists {
++			unverifiedManifest, err = manSvc.Get(digested.Digest())
++		}
++		tagOrDigest = digested.Digest().String()
++
++	} else {
++		if tagged, isTagged := ref.(reference.Tagged); isTagged {
++			tag = tagged.Tag()
++			exists, err = manSvc.ExistsByTag(tag)
++			if err != nil {
++				return nil, err
++			}
++			if err == nil && !exists {
++				return nil, fmt.Errorf("Tag %q does not exist in remote repository %s", tag, mf.repoInfo.CanonicalName.Name())
++			}
++
++		} else {
++			tagList, err := manSvc.Tags()
++			if err != nil {
++				return nil, err
++			}
++			for _, t := range tagList {
++				if t == tagpkg.DefaultTag {
++					tag = tagpkg.DefaultTag
++				}
++			}
++			if tag == "" && len(tagList) > 0 {
++				tag = tagList[0]
++			}
++			if tag == "" {
++				return nil, fmt.Errorf("No tags available for remote repository %s", mf.repoInfo.CanonicalName.Name())
++			}
++		}
++
++		unverifiedManifest, err = manSvc.GetByTag(tag)
++		tagOrDigest = tag
++	}
++
++	if err != nil {
++		return nil, err
++	}
++	if unverifiedManifest == nil {
++		return nil, fmt.Errorf("image manifest does not exist for tag or digest %q", tagOrDigest)
++	}
++
++	var verifiedManifest *schema1.Manifest
++	verifiedManifest, err = verifyManifest(unverifiedManifest, ref)
++	if err != nil {
++		return nil, err
++	}
++
++	rootFS := image.NewRootFS()
++
++	// remove duplicate layers and check parent chain validity
++	err = fixManifestLayers(verifiedManifest)
++	if err != nil {
++		return nil, err
++	}
++
++	// Image history converted to the new format
++	var history []image.History
++
++	// Note that the order of this loop is in the direction of bottom-most
++	// to top-most, so that the downloads slice gets ordered correctly.
++	for i := len(verifiedManifest.FSLayers) - 1; i >= 0; i-- {
++		var throwAway struct {
++			ThrowAway bool `json:"throwaway,omitempty"`
++		}
++		if err := json.Unmarshal([]byte(verifiedManifest.History[i].V1Compatibility), &throwAway); err != nil {
++			return nil, err
++		}
++
++		h, err := v1.HistoryFromConfig([]byte(verifiedManifest.History[i].V1Compatibility), throwAway.ThrowAway)
++		if err != nil {
++			return nil, err
++		}
++		history = append(history, h)
++	}
++
++	configRaw, err := v1.MakeRawConfigFromV1Config([]byte(unverifiedManifest.History[0].V1Compatibility), rootFS, history)
++	if err != nil {
++		return nil, err
++	}
++
++	config, err := json.Marshal(configRaw)
++	if err != nil {
++		return nil, err
++	}
++
++	dgst, _, err = digestFromManifest(unverifiedManifest, mf.repoInfo.LocalName.Name())
++	if err != nil {
++		return nil, err
++	}
++
++	img, err = image.NewFromJSON(config)
++	if err != nil {
++		return nil, err
++	}
++
++	return makeRemoteImageInspect(mf.repoInfo, img, tag, dgst), nil
++}
+diff --git a/distribution/list.go b/distribution/list.go
+new file mode 100644
+index 0000000..5d76ab9
+--- /dev/null
++++ b/distribution/list.go
+@@ -0,0 +1,173 @@
++package distribution
++
++import (
++	"fmt"
++	"io"
++	"sort"
++	"strings"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution/reference"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/registry"
++)
++
++type byTagName []*types.RepositoryTag
++
++func (r byTagName) Len() int           { return len(r) }
++func (r byTagName) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
++func (r byTagName) Less(i, j int) bool { return r[i].Tag < r[j].Tag }
++
++type byAPIVersion []registry.APIEndpoint
++
++func (r byAPIVersion) Len() int      { return len(r) }
++func (r byAPIVersion) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
++func (r byAPIVersion) Less(i, j int) bool {
++	if r[i].Version < r[j].Version {
++		return true
++	}
++	if r[i].Version == r[j].Version && strings.HasPrefix(r[i].URL, "https://") && !strings.HasPrefix(r[j].URL, "https://") {
++		return true
++	}
++	return false
++}
++
++// TagLister allows to list tags of remote repository.
++type TagLister interface {
++	ListTags() (tagList []*types.RepositoryTag, fallback bool, err error)
++}
++
++// ListRemoteTagsConfig allows to specify transport paramater for remote ta listing.
++type ListRemoteTagsConfig struct {
++	// MetaHeaders stores HTTP headers with metadata about the image
++	// (DockerHeaders with prefix X-Meta- in the request).
++	MetaHeaders map[string][]string
++	// AuthConfig holds authentication credentials for authenticating with
++	// the registry.
++	AuthConfig *types.AuthConfig
++	// OutStream is the output writer for showing the status of the pull
++	// operation.
++	OutStream io.Writer
++	// RegistryService is the registry service to use for TLS configuration
++	// and endpoint lookup.
++	RegistryService *registry.Service
++}
++
++// ListRemoteTags fetches a tag list from remote repository
++func ListRemoteTags(ref reference.Named, config *ListRemoteTagsConfig) (*types.RepositoryTagList, error) {
++	var tagList *types.RepositoryTagList
++	// Unless the index name is specified, iterate over all registries until
++	// the matching image is found.
++	if registry.IsReferenceFullyQualified(ref) {
++		return getRemoteTagList(ref, config)
++	}
++	if len(registry.RegistryList) == 0 {
++		return nil, fmt.Errorf("No configured registry to pull from.")
++	}
++	err := registry.ValidateRepositoryName(ref)
++	if err != nil {
++		return nil, err
++	}
++	for _, r := range registry.RegistryList {
++		// Prepend the index name to the image name.
++		fqr, _err := registry.FullyQualifyReferenceWith(r, ref)
++		if _err != nil {
++			logrus.Warnf("Failed to fully qualify %q name with %q registry: %v", ref.Name(), r, _err)
++			err = _err
++			continue
++		}
++		if tagList, err = getRemoteTagList(fqr, config); err == nil {
++			return tagList, nil
++		}
++	}
++	return tagList, err
++}
++
++// newTagLister creates a specific tag lister for given endpoint.
++func newTagLister(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, config *ListRemoteTagsConfig) (TagLister, error) {
++	switch endpoint.Version {
++	case registry.APIVersion2:
++		return &v2TagLister{
++			endpoint: endpoint,
++			config:   config,
++			repoInfo: repoInfo,
++		}, nil
++	case registry.APIVersion1:
++		return &v1TagLister{
++			endpoint: endpoint,
++			config:   config,
++			repoInfo: repoInfo,
++		}, nil
++	}
++	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
++}
++
++func getRemoteTagList(ref reference.Named, config *ListRemoteTagsConfig) (*types.RepositoryTagList, error) {
++	// Resolve the Repository name from fqn to RepositoryInfo
++	repoInfo, err := config.RegistryService.ResolveRepository(ref)
++	if err != nil {
++		return nil, err
++	}
++
++	if err := validateRepoName(repoInfo.LocalName.Name()); err != nil {
++		return nil, err
++	}
++
++	endpoints, err := config.RegistryService.LookupPullEndpoints(repoInfo.CanonicalName)
++	if err != nil {
++		return nil, err
++	}
++	// Prefer v1 versions which provide also image ids
++	sort.Sort(byAPIVersion(endpoints))
++
++	var (
++		lastErr error
++		// discardNoSupportErrors is used to track whether an endpoint encountered an error of type registry.ErrNoSupport
++		// By default it is false, which means that if a ErrNoSupport error is encountered, it will be saved in lastErr.
++		// As soon as another kind of error is encountered, discardNoSupportErrors is set to true, avoiding the saving of
++		// any subsequent ErrNoSupport errors in lastErr.
++		// It's needed for pull-by-digest on v1 endpoints: if there are only v1 endpoints configured, the error should be
++		// returned and displayed, but if there was a v2 endpoint which supports pull-by-digest, then the last relevant
++		// error is the ones from v2 endpoints not v1.
++		discardNoSupportErrors bool
++		tagList                = &types.RepositoryTagList{Name: repoInfo.CanonicalName.Name()}
++	)
++	for _, endpoint := range endpoints {
++		logrus.Debugf("Trying to fetch tag list of %s repository from %s %s", repoInfo.CanonicalName.String(), endpoint.URL, endpoint.Version)
++		fallback := false
++
++		tagLister, err := newTagLister(endpoint, repoInfo, config)
++		if err != nil {
++			lastErr = err
++			continue
++		}
++		tagList.TagList, fallback, err = tagLister.ListTags()
++		if err != nil {
++			// We're querying v1 registries first. Let's ignore errors until
++			// the first v2 registry.
++			if fallback || endpoint.Version == registry.APIVersion1 {
++				if _, ok := err.(registry.ErrNoSupport); !ok {
++					// Because we found an error that's not ErrNoSupport, discard all subsequent ErrNoSupport errors.
++					discardNoSupportErrors = true
++					// save the current error
++					lastErr = err
++				} else if !discardNoSupportErrors {
++					// Save the ErrNoSupport error, because it's either the first error or all encountered errors
++					// were also ErrNoSupport errors.
++					lastErr = err
++				}
++				continue
++			}
++			logrus.Debugf("Not continuing with error: %v", err)
++			return nil, err
++		}
++
++		sort.Sort(byTagName(tagList.TagList))
++		return tagList, nil
++	}
++
++	if lastErr == nil {
++		lastErr = fmt.Errorf("no endpoints found for %s", repoInfo.Index.Name)
++	}
++	return nil, lastErr
++}
+diff --git a/distribution/list_v1.go b/distribution/list_v1.go
+new file mode 100644
+index 0000000..8cc9dcb
+--- /dev/null
++++ b/distribution/list_v1.go
+@@ -0,0 +1,73 @@
++package distribution
++
++import (
++	"fmt"
++	"strings"
++
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution/registry/client/transport"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/registry"
++)
++
++type v1TagLister struct {
++	endpoint registry.APIEndpoint
++	config   *ListRemoteTagsConfig
++	repoInfo *registry.RepositoryInfo
++	session  *registry.Session
++}
++
++func (tl *v1TagLister) ListTags() ([]*types.RepositoryTag, bool, error) {
++	tlsConfig, err := tl.config.RegistryService.TLSConfig(tl.repoInfo.Index.Name)
++	if err != nil {
++		return nil, false, err
++	}
++	// Adds Docker-specific headers as well as user-specified headers (metaHeaders)
++	tr := transport.NewTransport(
++		// TODO(tiborvass): was ReceiveTimeout
++		registry.NewTransport(tlsConfig),
++		registry.DockerHeaders(tl.config.MetaHeaders)...,
++	)
++	client := registry.HTTPClient(tr)
++	v1Endpoint, err := tl.endpoint.ToV1Endpoint(tl.config.MetaHeaders)
++	if err != nil {
++		logrus.Debugf("Could not get v1 endpoint: %v", err)
++		return nil, true, err
++	}
++	tl.session, err = registry.NewSession(client, tl.config.AuthConfig, v1Endpoint)
++	if err != nil {
++		// TODO(dmcgowan): Check if should fallback
++		logrus.Debugf("Fallback from error: %s", err)
++		return nil, true, err
++	}
++	tagList, err := tl.listTagsWithSession()
++	return tagList, false, err
++}
++
++func (tl *v1TagLister) listTagsWithSession() ([]*types.RepositoryTag, error) {
++	repoData, err := tl.session.GetRepositoryData(tl.repoInfo.RemoteName)
++	if err != nil {
++		if strings.Contains(err.Error(), "HTTP code: 404") {
++			return nil, fmt.Errorf("Error: image %s not found", tl.repoInfo.RemoteName)
++		}
++		// Unexpected HTTP error
++		return nil, err
++	}
++
++	logrus.Debugf("Retrieving the tag list from V1 endpoints")
++	tagsList, err := tl.session.GetRemoteTags(repoData.Endpoints, tl.repoInfo.RemoteName)
++	if err != nil {
++		logrus.Errorf("Unable to get remote tags: %s", err)
++		return nil, err
++	}
++	if len(tagsList) < 1 {
++		return nil, fmt.Errorf("No tags available for remote repository %s", tl.repoInfo.CanonicalName)
++	}
++
++	tagList := make([]*types.RepositoryTag, 0, len(tagsList))
++	for tag, imageID := range tagsList {
++		tagList = append(tagList, &types.RepositoryTag{Tag: tag, ImageID: imageID})
++	}
++
++	return tagList, nil
++}
+diff --git a/distribution/list_v2.go b/distribution/list_v2.go
+new file mode 100644
+index 0000000..3c30028
+--- /dev/null
++++ b/distribution/list_v2.go
+@@ -0,0 +1,55 @@
++package distribution
++
++import (
++	"github.com/Sirupsen/logrus"
++	"github.com/docker/distribution"
++	"github.com/docker/distribution/registry/api/errcode"
++	"github.com/docker/docker/api/types"
++	"github.com/docker/docker/registry"
++	"golang.org/x/net/context"
++)
++
++type v2TagLister struct {
++	endpoint registry.APIEndpoint
++	config   *ListRemoteTagsConfig
++	repoInfo *registry.RepositoryInfo
++	repo     distribution.Repository
++}
++
++func (tl *v2TagLister) ListTags() (tagList []*types.RepositoryTag, fallback bool, err error) {
++	tl.repo, err = NewV2Repository(tl.repoInfo, tl.endpoint, tl.config.MetaHeaders, tl.config.AuthConfig)
++	if err != nil {
++		logrus.Debugf("Error getting v2 registry: %v", err)
++		return nil, true, err
++	}
++
++	tagList, err = tl.listTagsWithRepository()
++	if err != nil && registry.ContinueOnError(err) {
++		logrus.Debugf("Error trying v2 registry: %v", err)
++		fallback = true
++	}
++	return
++}
++
++func (tl *v2TagLister) listTagsWithRepository() ([]*types.RepositoryTag, error) {
++	logrus.Debugf("Retrieving the tag list from V2 endpoint %v", tl.endpoint.URL)
++	manSvc, err := tl.repo.Manifests(context.Background())
++	if err != nil {
++		return nil, err
++	}
++	tags, err := manSvc.Tags()
++	if err != nil {
++		switch t := err.(type) {
++		case errcode.Errors:
++			if len(t) == 1 {
++				return nil, t[0]
++			}
++		}
++		return nil, err
++	}
++	tagList := make([]*types.RepositoryTag, len(tags))
++	for i, tag := range tags {
++		tagList[i] = &types.RepositoryTag{Tag: tag}
++	}
++	return tagList, nil
++}
+diff --git a/image/v1/imagev1.go b/image/v1/imagev1.go
+index 4a67c01..ba93a16 100644
+--- a/image/v1/imagev1.go
++++ b/image/v1/imagev1.go
+@@ -66,8 +66,10 @@ func CreateID(v1Image image.V1Image, layerID layer.ChainID, parent digest.Digest
+ 	return digest.FromBytes(configJSON)
+ }
+ 
+-// MakeConfigFromV1Config creates an image config from the legacy V1 config format.
+-func MakeConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []image.History) ([]byte, error) {
++// MakeRawConfigFromV1Config creates an image config from the legacy V1 config
++// format and returns it as a map of json raw messages. No attributes will be
++// removed from the config.
++func MakeRawConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []image.History) (map[string]*json.RawMessage, error) {
+ 	var dver struct {
+ 		DockerVersion string `json:"docker_version"`
+ 	}
+@@ -95,6 +97,19 @@ func MakeConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []im
+ 		return nil, err
+ 	}
+ 
++	c["rootfs"] = rawJSON(rootfs)
++	c["history"] = rawJSON(history)
++
++	return c, nil
++}
++
++// MakeConfigFromV1Config creates an image config from the legacy V1 config format.
++func MakeConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []image.History) ([]byte, error) {
++	c, err := MakeRawConfigFromV1Config(imageJSON, rootfs, history)
++	if err != nil {
++		return nil, err
++	}
++
+ 	delete(c, "id")
+ 	delete(c, "parent")
+ 	delete(c, "Size") // Size is calculated from data on disk and is inconsitent
+@@ -102,9 +117,6 @@ func MakeConfigFromV1Config(imageJSON []byte, rootfs *image.RootFS, history []im
+ 	delete(c, "layer_id")
+ 	delete(c, "throwaway")
+ 
+-	c["rootfs"] = rawJSON(rootfs)
+-	c["history"] = rawJSON(history)
+-
+ 	return json.Marshal(c)
+ }
+ 
+diff --git a/integration-cli/docker_api_inspect_test.go b/integration-cli/docker_api_inspect_test.go
+index 37172b0..14db499 100644
+--- a/integration-cli/docker_api_inspect_test.go
++++ b/integration-cli/docker_api_inspect_test.go
+@@ -1,8 +1,11 @@
+ package main
+ 
+ import (
++	"bytes"
+ 	"encoding/json"
++	"fmt"
+ 	"net/http"
++	"reflect"
+ 	"strings"
+ 
+ 	"github.com/docker/docker/api/types"
+@@ -163,3 +166,220 @@ func (s *DockerSuite) TestInspectApiBridgeNetworkSettings121(c *check.C) {
+ 	c.Assert(settings.Networks["bridge"], checker.Not(checker.IsNil))
+ 	c.Assert(settings.IPAddress, checker.Equals, settings.Networks["bridge"].IPAddress)
+ }
++
++func compareInspectValues(c *check.C, name string, fst, snd interface{}, localVsRemote bool) {
++	additionalLocalAttributes := map[string]struct{}{}
++	additionalRemoteAttributes := map[string]struct{}{}
++	if localVsRemote {
++		additionalLocalAttributes = map[string]struct{}{
++			"GraphDriver": {},
++			"VirtualSize": {},
++		}
++		additionalRemoteAttributes = map[string]struct{}{"Registry": {}}
++	}
++
++	isRootObject := len(name) <= 1
++
++	compareArrays := func(lVal, rVal []interface{}) {
++		if len(lVal) != len(rVal) {
++			c.Errorf("array length differs between fst and snd for %q: %d != %d", name, len(lVal), len(rVal))
++		}
++		for i := 0; i < len(lVal) && i < len(rVal); i++ {
++			compareInspectValues(c, fmt.Sprintf("%s[%d]", name, i), lVal[i], rVal[i], localVsRemote)
++		}
++	}
++
++	if reflect.TypeOf(fst) != reflect.TypeOf(snd) {
++		c.Errorf("types don't match for %q: %T != %T", name, fst, snd)
++		return
++	}
++	switch fst.(type) {
++	case bool:
++		lVal := fst.(bool)
++		rVal := snd.(bool)
++		if lVal != rVal {
++			c.Errorf("fst value differs from snd for %q: %t != %t", name, lVal, rVal)
++		}
++
++	case float64:
++		lVal := fst.(float64)
++		rVal := snd.(float64)
++		if !strings.HasSuffix(name, ".Size") {
++			if lVal != rVal {
++				c.Errorf("fst value differs from snd for %q: %f != %f", name, lVal, rVal)
++			}
++		}
++
++	case string:
++		lVal := fst.(string)
++		rVal := snd.(string)
++		if !strings.HasSuffix(name, ".Id") && !strings.HasSuffix(name, ".Parent") {
++			if lVal != rVal {
++				c.Errorf("fst value differs from snd for %q: %q != %q", name, lVal, rVal)
++			}
++		}
++
++	// JSON array
++	case []interface{}:
++		lVal := fst.([]interface{})
++		rVal := snd.([]interface{})
++		if strings.HasSuffix(name, ".RepoTags") {
++			if len(rVal) != 1 {
++				c.Errorf("expected one item in remote Tags, not: %d", len(rVal))
++			} else {
++				found := false
++				for _, v := range lVal {
++					if v.(string) == rVal[0].(string) {
++						found = true
++						break
++					}
++				}
++				if !found {
++					c.Errorf("expected remote tag %q to be in among local ones: %v", rVal[0].(string), lVal)
++				}
++			}
++		} else if strings.HasSuffix(name, ".RepoDigests") {
++			if len(lVal) >= 1 {
++				compareArrays(lVal, rVal)
++			}
++			if len(rVal) != 1 {
++				c.Errorf("expected just one item in %q array, not %d (%v)", name, len(rVal), rVal)
++			}
++		} else {
++			compareArrays(lVal, rVal)
++		}
++
++	// JSON object
++	case map[string]interface{}:
++		lMap := fst.(map[string]interface{})
++		rMap := snd.(map[string]interface{})
++		if isRootObject && len(lMap)-len(additionalLocalAttributes) != len(rMap)-len(additionalRemoteAttributes) {
++			c.Errorf("got unexpected number of root object's attributes from snd inpect %q: %d != %d", name, len(lMap)-len(additionalLocalAttributes), len(rMap)-len(additionalRemoteAttributes))
++		} else if !isRootObject && len(lMap) != len(rMap) {
++			c.Errorf("map length differs between fst and snd for %q: %d != %d", name, len(lMap), len(rMap))
++		}
++		for key, lVal := range lMap {
++			itemName := fmt.Sprintf("%s.%s", name, key)
++			rVal, ok := rMap[key]
++			if ok {
++				compareInspectValues(c, itemName, lVal, rVal, localVsRemote)
++			} else if _, exists := additionalLocalAttributes[key]; !isRootObject || !localVsRemote || !exists {
++				c.Errorf("attribute %q present in fst but not in snd object", itemName)
++			}
++		}
++		for key := range rMap {
++			if _, ok := lMap[key]; !ok {
++				if _, exists := additionalRemoteAttributes[key]; !isRootObject || !localVsRemote || !exists {
++					c.Errorf("attribute \"%s.%s\" present in snd but not in fst object", name, key)
++				}
++			}
++		}
++
++	case nil:
++		if fst != snd {
++			c.Errorf("fst value differs from snd for %q: %v (%T) != %v (%T)", name, fst, fst, snd, snd)
++		}
++
++	default:
++		c.Fatalf("got unexpected type (%T) for %q", fst, name)
++	}
++}
++
++func apiCallInspectImage(c *check.C, d *Daemon, repoName string, remote, shouldFail bool) (value interface{}, status int, err error) {
++	suffix := ""
++	if remote {
++		suffix = "?remote=1"
++	}
++	endpoint := fmt.Sprintf("/v1.20/images/%s/json%s", repoName, suffix)
++	status, body, err := func() (int, []byte, error) {
++		if d == nil {
++			return sockRequest("GET", endpoint, nil)
++		}
++		return d.sockRequest("GET", endpoint, nil)
++	}()
++	if shouldFail {
++		c.Assert(status, check.Not(check.Equals), http.StatusOK)
++		if err == nil {
++			err = fmt.Errorf("%s", bytes.TrimSpace(body))
++		}
++	} else {
++		c.Assert(err, check.IsNil)
++		c.Assert(status, check.Equals, http.StatusOK)
++		if err = json.Unmarshal(body, &value); err != nil {
++			what := "local"
++			if remote {
++				what = "remote"
++			}
++			c.Fatalf("failed to parse result for %s image %q: %v", what, repoName, err)
++		}
++	}
++	return
++}
++
++func (s *DockerRegistrySuite) TestInspectApiRemoteImage(c *check.C) {
++	repoName := fmt.Sprintf("%v/dockercli/busybox", s.reg.url)
++	// tag the image and upload it to the private registry
++	dockerCmd(c, "tag", "busybox", repoName)
++	defer deleteImages(repoName)
++
++	dockerCmd(c, "push", repoName)
++	localValue, _, _ := apiCallInspectImage(c, nil, repoName, false, false)
++	remoteValue, _, _ := apiCallInspectImage(c, nil, repoName, true, false)
++	compareInspectValues(c, "a", localValue, remoteValue, true)
++
++	deleteImages(repoName)
++
++	// local inspect shall fail now
++	_, status, _ := apiCallInspectImage(c, nil, repoName, false, true)
++	c.Assert(status, check.Equals, http.StatusNotFound)
++
++	// remote inspect shall still succeed
++	remoteValue2, _, _ := apiCallInspectImage(c, nil, repoName, true, false)
++	compareInspectValues(c, "a", localValue, remoteValue2, true)
++}
++
++func (s *DockerRegistrySuite) TestInspectApiImageFromAdditionalRegistry(c *check.C) {
++	daemonArgs := []string{"--add-registry=" + s.reg.url}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	repoName := fmt.Sprintf("dockercli/busybox")
++	fqn := s.reg.url + "/" + repoName
++	// tag the image and upload it to the private registry
++	if out, err := s.d.Cmd("tag", "busybox", fqn); err != nil {
++		c.Fatalf("image tagging failed: %s, %v", out, err)
++	}
++
++	localValue, _, _ := apiCallInspectImage(c, s.d, repoName, false, false)
++
++	_, status, _ := apiCallInspectImage(c, s.d, repoName, true, true)
++	c.Assert(status, check.Equals, http.StatusNotFound)
++
++	if out, err := s.d.Cmd("push", fqn); err != nil {
++		c.Fatalf("failed to push image %s: error %v, output %q", fqn, err, out)
++	}
++
++	remoteValue, _, _ := apiCallInspectImage(c, s.d, repoName, true, false)
++	compareInspectValues(c, "a", localValue, remoteValue, true)
++
++	if out, err := s.d.Cmd("rmi", fqn); err != nil {
++		c.Fatalf("failed to remove image %s: %s, %v", fqn, out, err)
++	}
++
++	remoteValue2, _, _ := apiCallInspectImage(c, s.d, fqn, true, false)
++	compareInspectValues(c, "a", localValue, remoteValue2, true)
++}
++
++func (s *DockerRegistrySuite) TestInspectApiNonExistentRepository(c *check.C) {
++	repoName := fmt.Sprintf("%s/foo/non-existent", s.reg.url)
++
++	_, status, err := apiCallInspectImage(c, nil, repoName, false, true)
++	c.Assert(status, check.Equals, http.StatusNotFound)
++	c.Assert(err, check.Not(check.IsNil))
++	c.Assert(err.Error(), check.Matches, `(?i)no such image.*`)
++
++	_, status, err = apiCallInspectImage(c, nil, repoName, true, true)
++	c.Assert(err, check.Not(check.IsNil))
++	c.Assert(err.Error(), check.Matches, `(?i).*(not found|no such image|no tags available|not known).*`)
++}
+diff --git a/integration-cli/docker_api_tag_list_test.go b/integration-cli/docker_api_tag_list_test.go
+new file mode 100644
+index 0000000..0e0859d
+--- /dev/null
++++ b/integration-cli/docker_api_tag_list_test.go
+@@ -0,0 +1,234 @@
++package main
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++	"os"
++	"os/exec"
++	"path/filepath"
++	"strings"
++
++	"github.com/docker/docker/api/types"
++	"github.com/go-check/check"
++)
++
++func tagLinesEqual(expected, actual []string, allowEmptyImageID bool) bool {
++	if len(expected) != len(actual) {
++		return false
++	}
++	for i := range expected {
++		if i == 2 && actual[i] == "" && allowEmptyImageID {
++			continue
++		}
++		if expected[i] != actual[i] {
++			return false
++		}
++	}
++	return true
++}
++
++func dereferenceTagList(tagList []*types.RepositoryTag) []types.RepositoryTag {
++	res := make([]types.RepositoryTag, len(tagList))
++	for i, tag := range tagList {
++		res[i] = *tag
++	}
++	return res
++}
++
++func assertTagListEqual(c *check.C, d *Daemon, remote, allowEmptyImageID bool, name, expName string, expTagList []types.RepositoryTag) {
++	suffix := ""
++	if remote {
++		suffix = "?remote=1"
++	}
++	endpoint := fmt.Sprintf("/v1.20/images/%s/tags%s", name, suffix)
++	status, body, err := func() (int, []byte, error) {
++		if d == nil {
++			return sockRequest("GET", endpoint, nil)
++		}
++		return d.sockRequest("GET", endpoint, nil)
++	}()
++
++	c.Assert(status, check.Equals, http.StatusOK)
++	c.Assert(err, check.IsNil)
++
++	var tagList types.RepositoryTagList
++	if err = json.Unmarshal(body, &tagList); err != nil {
++		c.Fatalf("failed to parse tag list: %v", err)
++	}
++	if allowEmptyImageID {
++		for i, tag := range tagList.TagList {
++			if tag.ImageID == "" && i < len(expTagList) {
++				tag.ImageID = expTagList[i].ImageID
++			}
++		}
++	}
++	c.Assert(tagList.Name, check.Equals, expName)
++	c.Assert(dereferenceTagList(tagList.TagList), check.DeepEquals, expTagList)
++}
++
++func (s *DockerRegistriesSuite) TestTagApiListRemoteRepository(c *check.C) {
++	daemonArgs := []string{"--add-registry=" + s.reg2.url}
++	if err := s.d.StartWithBusybox(daemonArgs...); err != nil {
++		c.Fatalf("we should have been able to start the daemon with passing { %s } flags: %v", strings.Join(daemonArgs, ", "), err)
++	}
++
++	{ // load hello-world
++		bb := filepath.Join(s.d.folder, "hello-world.tar")
++		if _, err := os.Stat(bb); err != nil {
++			if !os.IsNotExist(err) {
++				c.Fatalf("unexpected error on hello-world.tar stat: %v", err)
++			}
++			// saving busybox image from main daemon
++			if err := exec.Command(dockerBinary, "save", "--output", bb, "hello-world:frozen").Run(); err != nil {
++				c.Fatalf("could not save hello-world:frozen image to %q: %v", bb, err)
++			}
++		}
++		// loading hello-world image to this daemon
++		if _, err := s.d.Cmd("load", "--input", bb); err != nil {
++			c.Fatalf("could not load hello-world image: %v", err)
++		}
++		if err := os.Remove(bb); err != nil {
++			s.d.c.Logf("could not remove %s: %v", bb, err)
++		}
++	}
++	busyboxID := s.d.getAndTestImageEntry(c, 2, "busybox", "").id
++	helloWorldID := s.d.getAndTestImageEntry(c, 2, "hello-world", "").id
++
++	for _, tag := range []string{"1.1-busy", "1.2-busy", "1.3-busy"} {
++		dest := s.reg1.url + "/foo/busybox:" + tag
++		if out, err := s.d.Cmd("tag", "busybox", dest); err != nil {
++			c.Fatalf("failed to tag image %q as %q: error %v, output %q", "busybox", dest, err, out)
++		}
++	}
++	for _, tag := range []string{"1.4-hell", "1.5-hell"} {
++		dest := s.reg1.url + "/foo/busybox:" + tag
++		if out, err := s.d.Cmd("tag", "hello-world:frozen", dest); err != nil {
++			c.Fatalf("failed to tag image %q as %q: error %v, output %q", "busybox", dest, err, out)
++		}
++	}
++	for _, tag := range []string{"2.1-busy", "2.2-busy", "2.3-busy"} {
++		dest := s.reg2.url + "/foo/busybox:" + tag
++		if out, err := s.d.Cmd("tag", "busybox", dest); err != nil {
++			c.Fatalf("failed to tag image %q as %q: error %v, output %q", "busybox", dest, err, out)
++		}
++	}
++	for _, tag := range []string{"2.4-hell", "2.5-hell"} {
++		dest := s.reg2.url + "/foo/busybox:" + tag
++		if out, err := s.d.Cmd("tag", "hello-world:frozen", dest); err != nil {
++			c.Fatalf("failed to tag image %q as %q: error %v, output %q", "busybox", dest, err, out)
++		}
++	}
++	localTags := []string{}
++	imgNames := []string{"busy", "hell"}
++	for ri, reg := range []*testRegistryV2{s.reg1, s.reg2} {
++		for i := 0; i < 5; i++ {
++			tag := fmt.Sprintf("%s/foo/busybox:%d.%d-%s", reg.url, ri+1, i+1, imgNames[i/3])
++			localTags = append(localTags, tag)
++			if (ri+i)%3 == 0 {
++				continue // upload 2/3 of registries
++			}
++			if out, err := s.d.Cmd("push", tag); err != nil {
++				c.Fatalf("push of %q should have succeeded: %v, output: %s", tag, err, out)
++			}
++		}
++	}
++
++	assertTagListEqual(c, s.d, true, true, s.reg1.url+"/foo/busybox", s.reg1.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"1.2-busy", busyboxID},
++			{"1.3-busy", busyboxID},
++			{"1.5-hell", helloWorldID},
++		})
++
++	assertTagListEqual(c, s.d, true, true, s.reg2.url+"/foo/busybox", s.reg2.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"2.1-busy", busyboxID},
++			{"2.2-busy", busyboxID},
++			{"2.4-hell", helloWorldID},
++			{"2.5-hell", helloWorldID},
++		})
++
++	assertTagListEqual(c, s.d, true, true, "foo/busybox", s.reg2.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"2.1-busy", busyboxID},
++			{"2.2-busy", busyboxID},
++			{"2.4-hell", helloWorldID},
++			{"2.5-hell", helloWorldID},
++		})
++
++	assertTagListEqual(c, s.d, false, false, s.reg1.url+"/foo/busybox", s.reg1.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"1.1-busy", busyboxID},
++			{"1.2-busy", busyboxID},
++			{"1.3-busy", busyboxID},
++			{"1.4-hell", helloWorldID},
++			{"1.5-hell", helloWorldID},
++		})
++
++	assertTagListEqual(c, s.d, false, false, s.reg2.url+"/foo/busybox", s.reg2.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"2.1-busy", busyboxID},
++			{"2.2-busy", busyboxID},
++			{"2.3-busy", busyboxID},
++			{"2.4-hell", helloWorldID},
++			{"2.5-hell", helloWorldID},
++		})
++
++	// now delete all local images
++	if out, err := s.d.Cmd("rmi", localTags...); err != nil {
++		c.Fatalf("failed to remove images %v: %v, output: %s", localTags, err, out)
++	}
++
++	// and try again
++	assertTagListEqual(c, s.d, true, true, "foo/busybox", s.reg2.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"2.1-busy", busyboxID},
++			{"2.2-busy", busyboxID},
++			{"2.4-hell", helloWorldID},
++			{"2.5-hell", helloWorldID},
++		})
++
++	assertTagListEqual(c, s.d, false, true, s.reg1.url+"/foo/busybox", s.reg1.url+"/foo/busybox",
++		[]types.RepositoryTag{
++			{"1.2-busy", busyboxID},
++			{"1.3-busy", busyboxID},
++			{"1.5-hell", helloWorldID},
++		})
++}
++
++func (s *DockerRegistrySuite) TestTagApiListNotExistentRepository(c *check.C) {
++	if err := s.d.StartWithBusybox(); err != nil {
++		c.Fatalf("we should have been able to start the daemon: %v", err)
++	}
++
++	busyboxID := s.d.getAndTestImageEntry(c, 1, "busybox", "").id
++
++	repoName := fmt.Sprintf("%s/foo/busybox", s.reg.url)
++	if out, err := s.d.Cmd("tag", "busybox", repoName); err != nil {
++		c.Fatalf("failed to tag image %q as %q: error %v, output %q", "busybox", repoName, err, out)
++	}
++	// list local tags
++	assertTagListEqual(c, s.d, false, false, repoName, repoName,
++		[]types.RepositoryTag{
++			{"latest", busyboxID},
++		})
++
++	// list remote tags - shall list nothing
++	endpoint := fmt.Sprintf("/v1.20/images/%s/tags?remote=1", repoName)
++	status, body, err := s.d.sockRequest("GET", endpoint, nil)
++
++	c.Assert(err, check.IsNil)
++	// Correct response status code is NotFound. However there's a bug in
++	// bundled registry code that returns OK with empty tag list when the
++	// registry does not exist.
++	if status != http.StatusNotFound && status != http.StatusOK {
++		c.Fatalf("got unexpected status code %d (not one of {%d, %d}", status, http.StatusNotFound, http.StatusOK)
++	}
++	var tagList types.RepositoryTagList
++	if status == http.StatusOK {
++		if err = json.Unmarshal(body, &tagList); err != nil {
++			c.Assert(tagList, check.Equals, types.RepositoryTagList{})
++		}
++	}
++}
+diff --git a/integration-cli/docker_utils.go b/integration-cli/docker_utils.go
+index 1f55584..b9a599a 100644
+--- a/integration-cli/docker_utils.go
++++ b/integration-cli/docker_utils.go
+@@ -504,7 +504,7 @@ func (d *Daemon) getImages(c *check.C, args ...string) map[string]*localImageEnt
+ 	reImageEntry := regexp.MustCompile(`(?m)^([[:alnum:]/.:_<>-]+)\s+([[:alnum:]._<>-]+)\s+((?:sha\d+:)?[a-fA-F0-9]+)\s+\S+\s+(.+)`)
+ 	result := make(map[string]*localImageEntry)
+ 
+-	out, err := d.Cmd("images", args...)
++	out, err := d.Cmd("images", append([]string{"--no-trunc"}, args...)...)
+ 	if err != nil {
+ 		c.Fatalf("failed to list images: %v", err)
+ 	}
+@@ -583,6 +583,77 @@ func (d *Daemon) inspectField(name, field string) (string, error) {
+ 	return strings.TrimSpace(out), nil
+ }
+ 
++func (d *Daemon) sockConn(timeout time.Duration) (net.Conn, error) {
++	daemon := d.sock()
++	daemonURL, err := url.Parse(daemon)
++	if err != nil {
++		return nil, fmt.Errorf("could not parse url %q: %v", daemon, err)
++	}
++
++	var c net.Conn
++	switch daemonURL.Scheme {
++	case "unix":
++		return net.DialTimeout(daemonURL.Scheme, daemonURL.Path, timeout)
++	case "tcp":
++		return net.DialTimeout(daemonURL.Scheme, daemonURL.Host, timeout)
++	default:
++		return c, fmt.Errorf("unknown scheme %v (%s)", daemonURL.Scheme, daemon)
++	}
++}
++
++func (d *Daemon) sockRequest(method, endpoint string, data interface{}) (int, []byte, error) {
++	jsonData := bytes.NewBuffer(nil)
++	if err := json.NewEncoder(jsonData).Encode(data); err != nil {
++		return -1, nil, err
++	}
++
++	res, body, err := d.sockRequestRaw(method, endpoint, jsonData, "application/json")
++	if err != nil {
++		return -1, nil, err
++	}
++	b, err := readBody(body)
++	return res.StatusCode, b, err
++}
++
++func (d *Daemon) sockRequestRaw(method, endpoint string, data io.Reader, ct string) (*http.Response, io.ReadCloser, error) {
++	req, client, err := d.newRequestClient(method, endpoint, data, ct)
++	if err != nil {
++		return nil, nil, err
++	}
++
++	resp, err := client.Do(req)
++	if err != nil {
++		client.Close()
++		return nil, nil, err
++	}
++	body := ioutils.NewReadCloserWrapper(resp.Body, func() error {
++		defer resp.Body.Close()
++		return client.Close()
++	})
++
++	return resp, body, nil
++}
++
++func (d *Daemon) newRequestClient(method, endpoint string, data io.Reader, ct string) (*http.Request, *httputil.ClientConn, error) {
++	c, err := d.sockConn(time.Duration(10 * time.Second))
++	if err != nil {
++		return nil, nil, fmt.Errorf("could not dial docker daemon: %v", err)
++	}
++
++	client := httputil.NewClientConn(c, nil)
++
++	req, err := http.NewRequest(method, endpoint, data)
++	if err != nil {
++		client.Close()
++		return nil, nil, fmt.Errorf("could not create new request: %v", err)
++	}
++
++	if ct != "" {
++		req.Header.Set("Content-Type", ct)
++	}
++	return req, client, nil
++}
++
+ func daemonHost() string {
+ 	daemonURLStr := "unix://" + opts.DefaultUnixSocket
+ 	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
+-- 
+2.5.0
+

--- a/patch/0013-Improved-searching-experience.patch
+++ b/patch/0013-Improved-searching-experience.patch
@@ -1,0 +1,848 @@
+From e38a36399fd95d6f003abfa50d547de093d489c5 Mon Sep 17 00:00:00 2001
+From: Dan Walsh <dwalsh@redhat.com>
+Date: Wed, 16 Dec 2015 14:07:15 -0500
+Subject: [PATCH 13/13] Improved searching experience
+
+- Prepend indicies to search results.
+- Prefix remote name with registry name.
+- Shorten index name if it's not an ip address.
+- Added `--no-index` option to avoid listing the index name.
+- Changed sorting of entries when index is preserved:
+
+  1. sort by `index_name`
+  2. sort by `star_count`
+  3. sort by `registry_name`
+  4. sort by `name`
+  5. sort by `description`
+
+- Changed sorting of entries when index is omitted:
+
+  1. sort by `registry_name`
+  2. sort by `star_count`
+  3. sort by `name`
+  4. sort by `description`
+
+Example (with just first two columns left):
+
+    $ sudo docker search mongo
+    INDEX       NAME                                                     DESCRIPTION
+    docker.io   docker.io/mongo                                          MongoDB docu...
+    [...]
+    myregistry  docker.io/mongo                                          test
+    [...]
+    redhat.com  docker-registry.usersys.redhat.com/goldmann/eap-mongodb
+    [...]
+
+Docker-DCO-1.1-Signed-off-by: Daniel Riek <riek@redhat.com>
+Signed-off-by: Michal Minar <miminar@redhat.com>
+
+Signed-off-by: Dan Walsh <dwalsh@redhat.com>
+---
+ api/client/client.go                          |   4 +-
+ api/client/lib/image_search.go                |   9 +-
+ api/client/search.go                          |  57 ++++---
+ api/server/router/local/image.go              |   4 +-
+ api/types/client.go                           |   1 +
+ daemon/daemon.go                              |   5 +-
+ docs/reference/api/docker_remote_api_v1.18.md |   7 +
+ man/docker-search.1.md                        |  22 ++-
+ registry/config.go                            |   2 +-
+ registry/registry_test.go                     | 151 ++++++++++++++++
+ registry/service.go                           | 236 +++++++++++++++++++++++---
+ registry/types.go                             |  23 +++
+ 12 files changed, 456 insertions(+), 65 deletions(-)
+
+diff --git a/api/client/client.go b/api/client/client.go
+index 5e737c2..256f58f 100644
+--- a/api/client/client.go
++++ b/api/client/client.go
+@@ -10,7 +10,7 @@ import (
+ 	"github.com/docker/docker/api/client/lib"
+ 	"github.com/docker/docker/api/types"
+ 	"github.com/docker/docker/api/types/filters"
+-	"github.com/docker/docker/api/types/registry"
++	"github.com/docker/docker/registry"
+ 	"github.com/docker/docker/runconfig"
+ )
+ 
+@@ -56,7 +56,7 @@ type apiClient interface {
+ 	ImagePull(options types.ImagePullOptions, privilegeFunc lib.RequestPrivilegeFunc) (io.ReadCloser, error)
+ 	ImagePush(options types.ImagePushOptions, privilegeFunc lib.RequestPrivilegeFunc) (io.ReadCloser, error)
+ 	ImageRemove(options types.ImageRemoveOptions) ([]types.ImageDelete, error)
+-	ImageSearch(options types.ImageSearchOptions, privilegeFunc lib.RequestPrivilegeFunc) ([]registry.SearchResult, error)
++	ImageSearch(options types.ImageSearchOptions, privilegeFunc lib.RequestPrivilegeFunc) ([]registry.SearchResultExt, error)
+ 	ImageSave(imageIDs []string) (io.ReadCloser, error)
+ 	ImageTag(options types.ImageTagOptions) error
+ 	Info() (types.Info, error)
+diff --git a/api/client/lib/image_search.go b/api/client/lib/image_search.go
+index 4e6bc7d..266263b 100644
+--- a/api/client/lib/image_search.go
++++ b/api/client/lib/image_search.go
+@@ -6,15 +6,18 @@ import (
+ 	"net/url"
+ 
+ 	"github.com/docker/docker/api/types"
+-	"github.com/docker/docker/api/types/registry"
++	"github.com/docker/docker/registry"
+ )
+ 
+ // ImageSearch makes the docker host to search by a term in a remote registry.
+ // The list of results is not sorted in any fashion.
+-func (cli *Client) ImageSearch(options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResult, error) {
+-	var results []registry.SearchResult
++func (cli *Client) ImageSearch(options types.ImageSearchOptions, privilegeFunc RequestPrivilegeFunc) ([]registry.SearchResultExt, error) {
++	var results []registry.SearchResultExt
+ 	query := url.Values{}
+ 	query.Set("term", options.Term)
++	if options.NoIndex {
++		query.Set("noIndex", "1")
++	}
+ 
+ 	resp, err := cli.tryImageSearch(query, options.RegistryAuth)
+ 	if resp.statusCode == http.StatusUnauthorized {
+diff --git a/api/client/search.go b/api/client/search.go
+index d627ef6..b8f8764 100644
+--- a/api/client/search.go
++++ b/api/client/search.go
+@@ -2,13 +2,12 @@ package client
+ 
+ import (
+ 	"fmt"
+-	"net/url"
+-	"sort"
++	"net"
++	"strconv"
+ 	"strings"
+ 	"text/tabwriter"
+ 
+ 	"github.com/docker/docker/api/types"
+-	registrytypes "github.com/docker/docker/api/types/registry"
+ 	Cli "github.com/docker/docker/cli"
+ 	flag "github.com/docker/docker/pkg/mflag"
+ 	"github.com/docker/docker/pkg/stringutils"
+@@ -21,6 +20,7 @@ import (
+ func (cli *DockerCli) CmdSearch(args ...string) error {
+ 	cmd := Cli.Subcmd("search", []string{"TERM"}, Cli.DockerCommands["search"].Description, true)
+ 	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
++	noIndex := cmd.Bool([]string{"#noindex", "-no-index"}, false, "Don't prepend index to output")
+ 	automated := cmd.Bool([]string{"-automated"}, false, "Only show automated builds")
+ 	stars := cmd.Uint([]string{"s", "-stars"}, 0, "Only displays with at least x stars")
+ 	cmd.Require(flag.Exact, 1)
+@@ -28,8 +28,6 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
+ 	cmd.ParseFlags(args, true)
+ 
+ 	name := cmd.Arg(0)
+-	v := url.Values{}
+-	v.Set("term", name)
+ 
+ 	indexInfo, err := registry.ParseSearchIndexInfo(name)
+ 	if err != nil {
+@@ -47,45 +45,58 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
+ 	options := types.ImageSearchOptions{
+ 		Term:         name,
+ 		RegistryAuth: encodedAuth,
++		NoIndex:      *noIndex,
+ 	}
+ 
+-	unorderedResults, err := cli.client.ImageSearch(options, requestPrivilege)
++	results, err := cli.client.ImageSearch(options, requestPrivilege)
+ 	if err != nil {
+ 		return err
+ 	}
+ 
+-	results := searchResultsByStars(unorderedResults)
+-	sort.Sort(results)
+-
+ 	w := tabwriter.NewWriter(cli.out, 10, 1, 3, ' ', 0)
+-	fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
++	if *noIndex {
++		fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
++	} else {
++		fmt.Fprintf(w, "INDEX\tNAME\tDESCRIPTION\tSTARS\tOFFICIAL\tAUTOMATED\n")
++	}
+ 	for _, res := range results {
+ 		if (*automated && !res.IsAutomated) || (int(*stars) > res.StarCount) {
+ 			continue
+ 		}
++		row := []string{}
++		if !*noIndex {
++			indexName := res.IndexName
++			if !*noTrunc {
++				// Shorten index name to DOMAIN.TLD unless --no-trunc is given.
++				if host, _, err := net.SplitHostPort(indexName); err == nil {
++					indexName = host
++				}
++				// do not shorten ip address
++				if net.ParseIP(indexName) == nil {
++					// shorten index name just to the last 2 components (`DOMAIN.TLD`)
++					indexNameSubStrings := strings.Split(indexName, ".")
++					if len(indexNameSubStrings) > 2 {
++						indexName = strings.Join(indexNameSubStrings[len(indexNameSubStrings)-2:], ".")
++					}
++				}
++			}
++			row = append(row, indexName)
++		}
++
+ 		desc := strings.Replace(res.Description, "\n", " ", -1)
+ 		desc = strings.Replace(desc, "\r", " ", -1)
+ 		if !*noTrunc && len(desc) > 45 {
+ 			desc = stringutils.Truncate(desc, 42) + "..."
+ 		}
+-		fmt.Fprintf(w, "%s\t%s\t%d\t", res.Name, desc, res.StarCount)
++		row = append(row, res.RegistryName+"/"+res.Name, desc, strconv.Itoa(res.StarCount), "", "")
+ 		if res.IsOfficial {
+-			fmt.Fprint(w, "[OK]")
+-
++			row[len(row)-2] = "[OK]"
+ 		}
+-		fmt.Fprint(w, "\t")
+ 		if res.IsAutomated || res.IsTrusted {
+-			fmt.Fprint(w, "[OK]")
++			row[len(row)-1] = "[OK]"
+ 		}
+-		fmt.Fprint(w, "\n")
++		fmt.Fprintf(w, "%s\n", strings.Join(row, "\t"))
+ 	}
+ 	w.Flush()
+ 	return nil
+ }
+-
+-// SearchResultsByStars sorts search results in descending order by number of stars.
+-type searchResultsByStars []registrytypes.SearchResult
+-
+-func (r searchResultsByStars) Len() int           { return len(r) }
+-func (r searchResultsByStars) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+-func (r searchResultsByStars) Less(i, j int) bool { return r[j].StarCount < r[i].StarCount }
+diff --git a/api/server/router/local/image.go b/api/server/router/local/image.go
+index 2af297a..0d2d18c 100644
+--- a/api/server/router/local/image.go
++++ b/api/server/router/local/image.go
+@@ -674,9 +674,9 @@ func (s *router) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *
+ 			headers[k] = v
+ 		}
+ 	}
+-	query, err := s.daemon.SearchRegistryForImages(r.Form.Get("term"), config, headers)
++	results, err := s.daemon.SearchRegistryForImages(r.Form.Get("term"), config, headers, httputils.BoolValue(r, "noIndex"))
+ 	if err != nil {
+ 		return err
+ 	}
+-	return httputils.WriteJSON(w, http.StatusOK, query.Results)
++	return httputils.WriteJSON(w, http.StatusOK, results)
+ }
+diff --git a/api/types/client.go b/api/types/client.go
+index c600b90..b8ebba1 100644
+--- a/api/types/client.go
++++ b/api/types/client.go
+@@ -202,6 +202,7 @@ type ImageRemoveOptions struct {
+ type ImageSearchOptions struct {
+ 	Term         string
+ 	RegistryAuth string
++	NoIndex      bool
+ }
+ 
+ // ImageTagOptions holds parameters to tag an image
+diff --git a/daemon/daemon.go b/daemon/daemon.go
+index 924a9e9..6c4a3b6 100644
+--- a/daemon/daemon.go
++++ b/daemon/daemon.go
+@@ -24,7 +24,6 @@ import (
+ 	"github.com/docker/docker/api"
+ 	"github.com/docker/docker/api/types"
+ 	"github.com/docker/docker/api/types/filters"
+-	registrytypes "github.com/docker/docker/api/types/registry"
+ 	"github.com/docker/docker/container"
+ 	"github.com/docker/docker/daemon/events"
+ 	"github.com/docker/docker/daemon/exec"
+@@ -1571,8 +1570,8 @@ func (daemon *Daemon) AuthenticateToRegistry(authConfig *types.AuthConfig) (stri
+ // term. authConfig is used to login.
+ func (daemon *Daemon) SearchRegistryForImages(term string,
+ 	authConfig *types.AuthConfig,
+-	headers map[string][]string) (*registrytypes.SearchResults, error) {
+-	return daemon.RegistryService.Search(term, authConfig, headers)
++	headers map[string][]string, noIndex bool) ([]registry.SearchResultExt, error) {
++	return daemon.RegistryService.Search(term, authConfig, headers, noIndex)
+ }
+ 
+ // IsShuttingDown tells whether the daemon is shutting down or not
+diff --git a/docs/reference/api/docker_remote_api_v1.18.md b/docs/reference/api/docker_remote_api_v1.18.md
+index 0ed2adf..6876598 100644
+--- a/docs/reference/api/docker_remote_api_v1.18.md
++++ b/docs/reference/api/docker_remote_api_v1.18.md
+@@ -1481,23 +1481,29 @@ Search for an image on [Docker Hub](https://hub.docker.com).
+         [
+                 {
+                     "description": "",
++                    "index_name" : "docker.io"
+                     "is_official": false,
+                     "is_automated": false,
+                     "name": "wma55/u1210sshd",
++                    "registry_name" : "docker.io",
+                     "star_count": 0
+                 },
+                 {
+                     "description": "",
++                    "index_name" : "docker.io"
+                     "is_official": false,
+                     "is_automated": false,
+                     "name": "jdswinbank/sshd",
++                    "registry_name" : "docker.io",
+                     "star_count": 0
+                 },
+                 {
+                     "description": "",
++                    "index_name" : "docker.io"
+                     "is_official": false,
+                     "is_automated": false,
+                     "name": "vgauthier/sshd",
++                    "registry_name" : "docker.io",
+                     "star_count": 0
+                 }
+         ...
+@@ -1506,6 +1512,7 @@ Search for an image on [Docker Hub](https://hub.docker.com).
+ Query Parameters:
+ 
+ -   **term** – term to search
++-   **noIndex** - whether to include `index_name` in result respons and sort results with it
+ 
+ Status Codes:
+ 
+diff --git a/man/docker-search.1.md b/man/docker-search.1.md
+index 0b205f4..d9f3cc3 100644
+--- a/man/docker-search.1.md
++++ b/man/docker-search.1.md
+@@ -25,7 +25,11 @@ of stars awarded, whether the image is official, and whether it is automated.
+    Only show automated builds. The default is *false*.
+ 
+ **--help**
+-  Print usage statement
++   Print usage statement
++
++**--no-index**=*true*|*false*
++   Do not include index name in output. Sort results primarily by registry
++   name.
+ 
+ **--no-trunc**=*true*|*false*
+    Don't truncate output. The default is *false*.
+@@ -41,11 +45,11 @@ Search a registry for the term 'fedora' and only display those images
+ ranked 3 or higher:
+ 
+     $ docker search -s 3 fedora
+-    NAME                  DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
+-    mattdm/fedora         A basic Fedora image corresponding roughly...  50
+-    fedora                (Semi) Official Fedora base image.             38
+-    mattdm/fedora-small   A small Fedora image on which to build. Co...  8
+-    goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
++    INDEX      NAME                            DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
++    docker.io  docker.io/mattdm/fedora         A basic Fedora image corresponding roughly...  50
++    docker.io  docker.io/fedora                (Semi) Official Fedora base image.             38
++    docker.io  docker.io/mattdm/fedora-small   A small Fedora image on which to build. Co...  8
++    docker.io  docker.io/goldmann/wildfly      A WildFly application server running on a ...  3               [OK]
+ 
+ ## Search Docker Hub for automated images
+ 
+@@ -53,9 +57,9 @@ Search Docker Hub for the term 'fedora' and only display automated images
+ ranked 1 or higher:
+ 
+     $ docker search --automated -s 1 fedora
+-    NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
+-    goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
+-    tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
++    INDEX      NAME                         DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
++    docker.io  docker.io/goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
++    docker.io  docker.io/tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
+ 
+ # HISTORY
+ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+diff --git a/registry/config.go b/registry/config.go
+index f8e80fb..e5cc3c5 100644
+--- a/registry/config.go
++++ b/registry/config.go
+@@ -437,7 +437,7 @@ func ParseRepositoryInfo(reposName reference.Named) (*RepositoryInfo, error) {
+ 
+ // ParseSearchIndexInfo will use repository name to get back an indexInfo.
+ func ParseSearchIndexInfo(reposName string) (*registrytypes.IndexInfo, error) {
+-	indexName, _ := splitReposSearchTerm(reposName)
++	indexName, _ := splitReposSearchTerm(reposName, true)
+ 
+ 	indexInfo, err := newIndexInfo(emptyServiceConfig, indexName)
+ 	if err != nil {
+diff --git a/registry/registry_test.go b/registry/registry_test.go
+index b21d6c1..7fa3dd9 100644
+--- a/registry/registry_test.go
++++ b/registry/registry_test.go
+@@ -1011,3 +1011,154 @@ func (tr debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+ 	tr.log(string(dump))
+ 	return resp, err
+ }
++
++var sortSearchResultsCases = []SearchResultExt{
++	{"docker.io", "isv.company.ltd", 10, false, "misc/image", false, false, "Some custom image."},
++	{"docker.io", "isv.company.ltd", 10, false, "custom/image", false, true, "Some custom image."},
++	{"index.company.ltd", "registry.stage.company.ltd", 6, false, "centos", true, false, "Another CentOS"},
++	{"docker.io", "docker.io", 5, false, "custom/image", false, true, "Some custom image from docker registry."},
++	{"127.0.0.1:5000", "127.0.0.1:5000", 0, false, "custom/image", false, false, "Image from private repo."},
++	{"docker.io", "registry.company.ltd", 0, false, "centos", true, true, "Second hand CentOS"},
++	{"docker.io", "docker.io", 0, false, "user/app", false, false, "Some user app."},
++	{"docker.io", "docker.io", 5, false, "user/app1", false, true, "Some user app."},
++	{"docker.io", "docker.io", 2, false, "user/app2", false, false, "Some user app."},
++	{"127.0.0.1:5000", "isv.company.ltd", 11, false, "custom/image", false, true, "Image from private repo."},
++	{"docker.io", "docker.io", 3, false, "user/app3", false, false, "Some user app."},
++	{"index.company.ltd", "registry.company.ltd", 11, false, "centos", true, true, "CentOS."},
++	{"docker.io", "docker.io", 0, true, "fedora/apache", true, false, "Official apache"},
++	{"docker.io", "registry.stage.company.ltd", 11, false, "centos", true, true, "CentOS from another registry."},
++	{"docker.io", "isv.another.comp.ltd", 9, false, "custom/image", false, false, "Custom image."},
++	{"index.company.ltd", "isv.company.ltd", 10, false, "custom/image", false, true, "Some custom image."},
++	{"index.company.ltd", "isv.company.ltd", 11, false, "custom/image", false, false, "Some custom image."},
++	{"127.0.0.1:5000", "127.0.0.1:5000", 0, false, "centos", false, true, "CentOS from private repo."},
++	{"127.0.0.1:5000", "docker.io", 0, false, "user/app2", false, false, "User app from private registry."},
++}
++
++// `sortedEntriesMapping` maps new position in the list to original one after
++// the sort. `duplicates` is a list of duplicate entries that should be removed
++// after the call to `removeSearchDuplicates`. May be null if sorting with
++// index.
++func doTestSortSearchResults(t *testing.T, withIndex bool, sortedEntriesMapping map[int]int, duplicates []int) {
++	cases := make([]SearchResultExt, len(sortSearchResultsCases))
++	for i := range sortSearchResultsCases {
++		cases[i] = sortSearchResultsCases[i]
++	}
++	by(getSearchResultsCmpFunc(withIndex)).Sort(cases)
++
++	for i, entry := range sortSearchResultsCases {
++		if newPos, ok := sortedEntriesMapping[i]; !ok {
++			t.Fatalf("sortedEntriesMapping is incomplete (%d index is missing)", i)
++		} else if newPos > len(cases) {
++			t.Fatalf("expected position for entry %d is out of range (%d >= %d)", i, newPos, len(cases))
++		}
++		if cases[sortedEntriesMapping[i]] != entry {
++			j := 0
++			for ; j < len(cases); j++ {
++				if cases[j] == entry {
++					break
++				}
++			}
++			if j >= len(sortSearchResultsCases) {
++				t.Fatalf("sortedEntriesMapping is incomplete")
++			}
++			t.Errorf("Sort failed, item %v (orig. pos=%d) expected on position %d, not %d.", entry, i, sortedEntriesMapping[i], j)
++		}
++	}
++
++	if !withIndex {
++		cases := removeSearchDuplicates(cases)
++		if len(cases) != len(sortSearchResultsCases)-len(duplicates) {
++			t.Errorf("Expected %d items in output table after removing duplicates, not %d.",
++				len(sortSearchResultsCases)-len(duplicates), len(cases))
++		}
++
++		for i, entry := range sortSearchResultsCases {
++			isRedundant := false
++			for j := range duplicates {
++				if i == duplicates[j] {
++					isRedundant = true
++					break
++				}
++			}
++			found := false
++			j := 0
++			for ; j < len(cases); j++ {
++				if entry == cases[j] {
++					found = true
++					break
++				}
++			}
++			if found && isRedundant {
++				t.Errorf("Entry %v (orig. pos=%d, new pos=%d) is redundant and should have been removed.", entry, i, j)
++			} else if !found && !isRedundant {
++				t.Errorf("Entry %v (orig. pos=%d) should have stayed in cases results.", entry, i)
++			}
++		}
++	}
++}
++
++func TestSortSearchResultsWithIndex(t *testing.T) {
++	sortedEntriesMapping := map[int]int{
++		0:  6,
++		1:  5,
++		2:  18,
++		3:  8,
++		4:  2,
++		5:  14,
++		6:  13,
++		7:  9,
++		8:  11,
++		9:  0,
++		10: 10,
++		11: 16,
++		12: 12,
++		13: 4,
++		14: 7,
++		15: 17,
++		16: 15,
++		17: 1,
++		18: 3,
++	}
++
++	// Should have not effect.
++	RegistryList = append([]string{"index.company.ltd"}, RegistryList...)
++	defer func() {
++		RegistryList = []string{IndexName}
++	}()
++
++	doTestSortSearchResults(t, true, sortedEntriesMapping, nil)
++}
++
++func TestSortSearchResultsWithoutIndex(t *testing.T) {
++	sortedEntriesMapping := map[int]int{
++		0:  14,
++		1:  13, // duplicate with 9, 15, 16
++		2:  18, // duplicate with 13
++		3:  2,
++		4:  1,
++		5:  16, // duplicate with 11
++		6:  7,
++		7:  3,
++		8:  5,
++		9:  10, // duplicate with 1, 15, 16
++		10: 4,
++		11: 15, // duplicate with 5
++		12: 6,
++		13: 17, //duplicate with 2
++		14: 9,
++		15: 12, // duplicate with 1, 9, 16
++		16: 11, // duplicate with 1, 9, 15
++		17: 0,
++		18: 8,
++	}
++
++	duplicates := []int{1, 5, 9, 13, 15}
++
++	// Duplicates having index nearest the first item in this list should have higher preference.
++	RegistryList = append([]string{"index.company.ltd"}, RegistryList...)
++	defer func() {
++		RegistryList = []string{IndexName}
++	}()
++
++	doTestSortSearchResults(t, false, sortedEntriesMapping, duplicates)
++}
+diff --git a/registry/service.go b/registry/service.go
+index 6eab776..09e65bf 100644
+--- a/registry/service.go
++++ b/registry/service.go
+@@ -5,8 +5,10 @@ import (
+ 	"fmt"
+ 	"net/http"
+ 	"net/url"
++	"sort"
+ 	"strings"
+ 
++	"github.com/Sirupsen/logrus"
+ 	"github.com/docker/distribution/reference"
+ 	"github.com/docker/distribution/registry/client/auth"
+ 	"github.com/docker/docker/api/types"
+@@ -58,48 +60,90 @@ func (s *Service) Auth(authConfig *types.AuthConfig) (string, error) {
+ 	return Login(authConfig, endpoint)
+ }
+ 
+-// splitReposSearchTerm breaks a search term into an index name and remote name
+-func splitReposSearchTerm(reposName string) (string, string) {
+-	nameParts := strings.SplitN(reposName, "/", 2)
+-	var indexName, remoteName string
+-	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
+-		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
+-		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
+-		// 'docker.io'
+-		indexName = IndexName
+-		remoteName = reposName
+-	} else {
+-		indexName = nameParts[0]
+-		remoteName = nameParts[1]
++type by func(fst, snd *SearchResultExt) bool
++
++type searchResultSorter struct {
++	Results []SearchResultExt
++	By      func(fst, snd *SearchResultExt) bool
++}
++
++func (by by) Sort(results []SearchResultExt) {
++	rs := &searchResultSorter{
++		Results: results,
++		By:      by,
+ 	}
+-	return indexName, remoteName
++	sort.Sort(rs)
++}
++
++func (s *searchResultSorter) Swap(i, j int) {
++	s.Results[i], s.Results[j] = s.Results[j], s.Results[i]
++}
++
++func (s *searchResultSorter) Less(i, j int) bool {
++	return s.By(&s.Results[i], &s.Results[j])
++}
++
++// Factory for search result comparison function. Either it takes index name
++// into consideration or not.
++func getSearchResultsCmpFunc(withIndex bool) by {
++	// Compare two items in the result table of search command. First compare
++	// the index we found the result in. Second compare their rating. Then
++	// compare their fully qualified name (registry/name).
++	less := func(fst, snd *SearchResultExt) bool {
++		if withIndex {
++			if fst.IndexName != snd.IndexName {
++				return fst.IndexName < snd.IndexName
++			}
++			if fst.StarCount != snd.StarCount {
++				return fst.StarCount > snd.StarCount
++			}
++		}
++		if fst.RegistryName != snd.RegistryName {
++			return fst.RegistryName < snd.RegistryName
++		}
++		if !withIndex {
++			if fst.StarCount != snd.StarCount {
++				return fst.StarCount > snd.StarCount
++			}
++		}
++		if fst.Name != snd.Name {
++			return fst.Name < snd.Name
++		}
++		return fst.Description < snd.Description
++	}
++	return less
++}
++
++func (s *searchResultSorter) Len() int {
++	return len(s.Results)
+ }
+ 
+ // Search queries the public registry for images matching the specified
+ // search terms, and returns the results.
+-func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[string][]string) (*registrytypes.SearchResults, error) {
++func (s *Service) searchTerm(term string, authConfig *types.AuthConfig, headers map[string][]string, noIndex bool, outs *[]SearchResultExt) error {
+ 	if err := validateNoSchema(term); err != nil {
+-		return nil, err
++		return err
+ 	}
+ 
+-	indexName, remoteName := splitReposSearchTerm(term)
++	indexName, remoteName := splitReposSearchTerm(term, true)
+ 
+ 	index, err := newIndexInfo(s.Config, indexName)
+ 	if err != nil {
+-		return nil, err
++		return err
+ 	}
+ 
+ 	// *TODO: Search multiple indexes.
+ 	endpoint, err := NewEndpoint(index, http.Header(headers), APIVersionUnknown)
+ 	if err != nil {
+-		return nil, err
++		return err
+ 	}
+ 
+ 	r, err := NewSession(endpoint.client, authConfig, endpoint)
+ 	if err != nil {
+-		return nil, err
++		return err
+ 	}
+ 
++	var results *registrytypes.SearchResults
+ 	if index.Official {
+ 		localName := remoteName
+ 		if strings.HasPrefix(localName, OfficialReposNamePrefix) {
+@@ -107,9 +151,157 @@ func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[
+ 			localName = strings.SplitN(localName, "/", 2)[1]
+ 		}
+ 
+-		return r.SearchRepositories(localName)
++		results, err = r.SearchRepositories(localName)
++	} else {
++		results, err = r.SearchRepositories(remoteName)
++	}
++	if err != nil || results.NumResults < 1 {
++		return err
++	}
++
++	newOuts := make([]SearchResultExt, len(*outs)+len(results.Results))
++	for i := range *outs {
++		newOuts[i] = (*outs)[i]
+ 	}
+-	return r.SearchRepositories(remoteName)
++	for i, result := range results.Results {
++		item := SearchResultExt{
++			IndexName:    index.Name,
++			RegistryName: index.Name,
++			StarCount:    result.StarCount,
++			Name:         result.Name,
++			IsOfficial:   result.IsOfficial,
++			IsTrusted:    result.IsTrusted,
++			IsAutomated:  result.IsAutomated,
++			Description:  result.Description,
++		}
++		// Check if search result is fully qualified with registry
++		// If not, assume REGISTRY = INDEX
++		newRegistryName, newName := splitReposSearchTerm(result.Name, false)
++		if newRegistryName != "" {
++			item.RegistryName, item.Name = newRegistryName, newName
++		}
++		newOuts[len(*outs)+i] = item
++	}
++	*outs = newOuts
++	return nil
++}
++
++// Duplicate entries may occur in result table when omitting index from output because
++// different indexes may refer to same registries.
++func removeSearchDuplicates(data []SearchResultExt) []SearchResultExt {
++	var (
++		prevIndex = 0
++		res       []SearchResultExt
++	)
++
++	if len(data) > 0 {
++		res = []SearchResultExt{data[0]}
++	}
++	for i := 1; i < len(data); i++ {
++		prev := res[prevIndex]
++		curr := data[i]
++		if prev.RegistryName == curr.RegistryName && prev.Name == curr.Name {
++			// Repositories are equal, delete one of them.
++			// Find out whose index has higher priority (the lower the number
++			// the higher the priority).
++			var prioPrev, prioCurr int
++			for prioPrev = 0; prioPrev < len(RegistryList); prioPrev++ {
++				if prev.IndexName == RegistryList[prioPrev] {
++					break
++				}
++			}
++			for prioCurr = 0; prioCurr < len(RegistryList); prioCurr++ {
++				if curr.IndexName == RegistryList[prioCurr] {
++					break
++				}
++			}
++			if prioPrev > prioCurr || (prioPrev == prioCurr && prev.StarCount < curr.StarCount) {
++				// replace previous entry with current one
++				res[prevIndex] = curr
++			} // otherwise keep previous entry
++		} else {
++			prevIndex++
++			res = append(res, curr)
++		}
++	}
++	return res
++}
++
++// Search queries several registries for images matching the specified
++// search terms, and returns the results.
++func (s *Service) Search(term string, authConfig *types.AuthConfig, headers map[string][]string, noIndex bool) ([]SearchResultExt, error) {
++	results := []SearchResultExt{}
++	cmpFunc := getSearchResultsCmpFunc(!noIndex)
++
++	// helper for concurrent queries
++	searchRoutine := func(term string, c chan<- error) {
++		err := s.searchTerm(term, authConfig, headers, noIndex, &results)
++		c <- err
++	}
++
++	if isReposSearchTermFullyQualified(term) {
++		if err := s.searchTerm(term, authConfig, headers, noIndex, &results); err != nil {
++			return nil, err
++		}
++	} else if len(RegistryList) < 1 {
++		return nil, fmt.Errorf("No configured repository to search.")
++	} else {
++		var (
++			err              error
++			successfulSearch = false
++			resultChan       = make(chan error)
++		)
++		// query all registries in parallel
++		for i, r := range RegistryList {
++			tmp := term
++			if i > 0 {
++				tmp = fmt.Sprintf("%s/%s", r, term)
++			}
++			go searchRoutine(tmp, resultChan)
++		}
++		for range RegistryList {
++			err = <-resultChan
++			if err == nil {
++				successfulSearch = true
++			} else {
++				logrus.Errorf("%s", err.Error())
++			}
++		}
++		if !successfulSearch {
++			return nil, err
++		}
++	}
++	by(cmpFunc).Sort(results)
++	if noIndex {
++		results = removeSearchDuplicates(results)
++	}
++	return results, nil
++}
++
++// splitReposSearchTerm breaks a search term into an index name and remote name
++func splitReposSearchTerm(reposName string, fixMissingIndex bool) (string, string) {
++	nameParts := strings.SplitN(reposName, "/", 2)
++	var indexName, remoteName string
++	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
++		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
++		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
++		// 'docker.io'
++		if fixMissingIndex {
++			indexName = IndexServerName()
++		} else {
++			indexName = ""
++		}
++		remoteName = reposName
++	} else {
++		indexName = nameParts[0]
++		remoteName = nameParts[1]
++	}
++	return indexName, remoteName
++}
++
++func isReposSearchTermFullyQualified(term string) bool {
++	indexName, _ := splitReposSearchTerm(term, false)
++	return indexName != ""
+ }
+ 
+ // ResolveRepository splits a repository name into its components
+diff --git a/registry/types.go b/registry/types.go
+index 0365782..63c8615 100644
+--- a/registry/types.go
++++ b/registry/types.go
+@@ -76,3 +76,26 @@ type RepositoryInfo struct {
+ 	// contain a '/' (e.g. "foo"), then it is considered an official repo.
+ 	Official bool
+ }
++
++// SearchResultExt describes a search result returned from a registry extended for
++// IndexName and RegistryName.
++// GET "/images/search"
++type SearchResultExt struct {
++	// IndexName is a name of index server providing the data below.
++	IndexName string `json:"index_name"`
++	// RegistryName is a registry name part of the Name. If the Name is not fully
++	// qualified, it will be set to IndexName.
++	RegistryName string `json:"registry_name"`
++	// StarCount indicates the number of stars this repository has
++	StarCount int `json:"star_count"`
++	// IsOfficial indicates whether the result is an official repository or not
++	IsOfficial bool `json:"is_official"`
++	// Name is the name of the repository
++	Name string `json:"name"`
++	// IsOfficial indicates whether the result is trusted
++	IsTrusted bool `json:"is_trusted"`
++	// IsAutomated indicates whether the result is automated
++	IsAutomated bool `json:"is_automated"`
++	// Description is a textual description of the repository
++	Description string `json:"description"`
++}
+-- 
+2.5.0
+

--- a/patch/0014-info-show-registries.patch
+++ b/patch/0014-info-show-registries.patch
@@ -1,0 +1,150 @@
+From f9f86982915872890174815fda3aefd362acd667 Mon Sep 17 00:00:00 2001
+From: Antonio Murdaca <runcom@redhat.com>
+Date: Thu, 19 Nov 2015 12:27:29 +0100
+Subject: [PATCH 14/14] info: show registries
+
+Signed-off-by: Antonio Murdaca <runcom@redhat.com>
+---
+ api/client/info.go                      | 13 +++++++++++++
+ api/types/types.go                      |  7 +++++++
+ daemon/info.go                          | 12 +++++++++++-
+ integration-cli/docker_cli_info_test.go | 14 ++++++++++++++
+ man/docker-info.1.md                    |  1 +
+ 5 files changed, 46 insertions(+), 1 deletion(-)
+
+diff --git a/api/client/info.go b/api/client/info.go
+index bc25a66..c1dab74 100644
+--- a/api/client/info.go
++++ b/api/client/info.go
+@@ -2,6 +2,7 @@ package client
+ 
+ import (
+ 	"fmt"
++	"strings"
+ 
+ 	Cli "github.com/docker/docker/cli"
+ 	"github.com/docker/docker/daemon/execdriver/dockerhooks"
+@@ -136,5 +137,17 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
+ 	if info.ClusterAdvertise != "" {
+ 		fmt.Fprintf(cli.out, "Cluster advertise: %s\n", info.ClusterAdvertise)
+ 	}
++
++	fmt.Fprintf(cli.out, "Registries: ")
++	regs := []string{}
++	for _, r := range info.Registries {
++		s := "secure"
++		if !r.Secure {
++			s = "insecure"
++		}
++		regs = append(regs, fmt.Sprintf("%s (%s)", r.Name, s))
++	}
++	fmt.Fprintf(cli.out, "%s", strings.Join(regs, ", "))
++
+ 	return nil
+ }
+diff --git a/api/types/types.go b/api/types/types.go
+index 0b89500..3de2b1c 100644
+--- a/api/types/types.go
++++ b/api/types/types.go
+@@ -194,6 +194,12 @@ type Version struct {
+ 	PkgVersion    string `json:",omitempty"`
+ }
+ 
++// Registry holds information about a specific registry
++type Registry struct {
++	Name   string
++	Secure bool
++}
++
+ // Info contains response of Remote API:
+ // GET "/info"
+ type Info struct {
+@@ -241,6 +247,7 @@ type Info struct {
+ 	ServerVersion      string
+ 	ClusterStore       string
+ 	ClusterAdvertise   string
++	Registries         []Registry
+ }
+ 
+ // PluginsInfo is temp struct holds Plugins name
+diff --git a/daemon/info.go b/daemon/info.go
+index d8efaf6..43fc85a 100644
+--- a/daemon/info.go
++++ b/daemon/info.go
+@@ -1,6 +1,7 @@
+ package daemon
+ 
+ import (
++	"net"
+ 	"os"
+ 	"runtime"
+ 	"strings"
+@@ -18,7 +19,7 @@ import (
+ 	"github.com/docker/docker/pkg/system"
+ 	"github.com/docker/docker/registry"
+ 	"github.com/docker/docker/utils"
+-	"github.com/docker/docker/volume/drivers"
++	volumedrivers "github.com/docker/docker/volume/drivers"
+ )
+ 
+ // SystemInfo returns information about the host server the daemon is running on.
+@@ -56,6 +57,14 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 	sysInfo := sysinfo.New(true)
+ 	packageVersion, _ := rpm.Version("/usr/bin/docker")
+ 
++	registries := []types.Registry{}
++	for _, ir := range daemon.RegistryService.Config.InsecureRegistryCIDRs {
++		registries = append(registries, types.Registry{(*net.IPNet)(ir).String(), false})
++	}
++	for n, i := range daemon.RegistryService.Config.IndexConfigs {
++		registries = append(registries, types.Registry{n, i.Secure})
++	}
++
+ 	v := &types.Info{
+ 		ID:                 daemon.ID,
+ 		Containers:         len(daemon.List()),
+@@ -93,6 +102,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
+ 		HTTPSProxy:         getProxyEnv("https_proxy"),
+ 		NoProxy:            getProxyEnv("no_proxy"),
+ 		PkgVersion:         packageVersion,
++		Registries:         registries,
+ 	}
+ 
+ 	// TODO Windows. Refactor this more once sysinfo is refactored into
+diff --git a/integration-cli/docker_cli_info_test.go b/integration-cli/docker_cli_info_test.go
+index 1eb090a..8c1f0cc 100644
+--- a/integration-cli/docker_cli_info_test.go
++++ b/integration-cli/docker_cli_info_test.go
+@@ -101,3 +101,17 @@ func (s *DockerSuite) TestInfoDiscoveryAdvertiseInterfaceName(c *check.C) {
+ 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster store: %s\n", discoveryBackend))
+ 	c.Assert(out, checker.Contains, fmt.Sprintf("Cluster advertise: %s:2375\n", ip.String()))
+ }
++
++func (s *DockerSuite) TestInfoRegistries(c *check.C) {
++	out, _ := dockerCmd(c, "info")
++	c.Assert(out, checker.Contains, "127.0.0.0/8 (insecure), docker.io (secure)")
++}
++
++func (s *DockerRegistriesSuite) TestInfoRegistriesAdditional(c *check.C) {
++	d := NewDaemon(c)
++	c.Assert(d.StartWithBusybox("--add-registry="+s.reg1.url, "--insecure-registry="+s.reg2.url), check.IsNil)
++	defer d.Stop()
++	out, _ := d.Cmd("info")
++	c.Assert(out, checker.Contains, s.reg1.url+" (insecure)")
++	c.Assert(out, checker.Contains, s.reg2.url+" (insecure)")
++}
+diff --git a/man/docker-info.1.md b/man/docker-info.1.md
+index eeb90ae..ebddc86 100644
+--- a/man/docker-info.1.md
++++ b/man/docker-info.1.md
+@@ -49,6 +49,7 @@ Here is a sample output:
+     Number of Hooks: 2
+     CPUs: 1
+     Total Memory: 2 GiB
++    Registries: docker.io (secure), 127.0.0.0/8 (insecure)
+ 
+ # HISTORY
+ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+-- 
+2.5.0
+


### PR DESCRIPTION
You all might dislike this so feel free to just close it :)

This patch basically saves our currently applied patches under `patches/` (much like distributions packagers do with src package with applied patches)

You'll find a script `patches/export_patches.sh` which basically helps you exporting patches from `HEAD` (there's a short usage in the script also)
I did this so we have all patches around and when rebasing fedora-1.* branches we won't forget any patch.
So everytime we apply a patch we could export it (`./patches/export_patches.sh 1`) and save it in the repo. Everytime we need to save all applied patches to rebase the branch, we first export them, rebase and reapply them (taking care of conflicts), and then reexport them (to have the latest applied ones)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>