### PR TITLE
Use -z,muldefs on arm,x86

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -19,6 +19,22 @@ if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARC
 	esac
 fi
 
+if [ "$(go env GOOS)" == "linux" ] ; then
+	case "$(go env GOARCH)" in
+		arm*|386)
+			# linking for Linux on arm or x86 needs external linking to avoid
+			# https://github.com/golang/go/issues/9510 until we move to Go 1.6
+			if [ "$IAMSTATIC" == "true" ] ; then
+				export EXTLDFLAGS_STATIC="$EXTLDFLAGS_STATIC -zmuldefs"
+				export LDFLAGS_STATIC_DOCKER="$LDFLAGS_STATIC -extldflags \"$EXTLDFLAGS_STATIC\""
+
+			else
+				export LDFLAGS="$LDFLAGS -extldflags -zmuldefs"
+			fi
+			;;
+	esac
+fi
+
 echo "Building: $DEST/$BINARY_FULLNAME"
 go build \
 	-o "$DEST/$BINARY_FULLNAME" \


### PR DESCRIPTION
Pull in changes from upstream PR#18197:

Assume that the linker can make sense of us passing in the -z,muldefs
option to tell it to ignore symbol-multiply-defined errors triggered by
https://github.com/golang/go/issues/9510.  We should be able to stop
doing this once we move to Go 1.6.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com> (github: nalind)