### PR TITLE
Add authentication support for default registries

### DIFF
--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -42,12 +42,18 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	if isTrusted() && !ref.HasDigest() {
 		// Check if tag is digest
 		authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+		// XXX: fix this for multiple authconfigs if additional registries are specified
 		return cli.trustedPull(repoInfo, ref, authConfig)
 	}
 
 	v := url.Values{}
 	v.Set("fromImage", ref.ImageName(taglessRemote))
 
-	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, repoInfo.Index, "pull")
+	var index *registry.IndexInfo
+	if registry.RepositoryNameHasIndex(remote) {
+		index = repoInfo.Index
+	}
+
+	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, index, "pull")
 	return err
 }

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -27,16 +27,21 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 		return err
 	}
 
-	// Resolve the Auth config relevant for this server
-	authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
-
 	if isTrusted() {
+		// Resolve the Auth config relevant for this server
+		authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+		// XXX: fix this for multiple authconfigs if additional registries are specified
 		return cli.trustedPush(repoInfo, tag, authConfig)
 	}
 
 	v := url.Values{}
 	v.Set("tag", tag)
 
-	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/"+remote+"/push?"+v.Encode(), nil, cli.out, repoInfo.Index, "push")
+	var index *registry.IndexInfo
+	if registry.RepositoryNameHasIndex(remote) {
+		index = repoInfo.Index
+	}
+
+	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/"+remote+"/push?"+v.Encode(), nil, cli.out, index, "push")
 	return err
 }

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -37,15 +37,21 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		v.Set("noIndex", "1")
 	}
 
-	// Resolve the Repository name from fqn to hostname + name
-	taglessRemote, _ := parsers.ParseRepositoryTag(name)
+	var (
+		index *registry.IndexInfo
+		err   error
+	)
 
-	indexInfo, err := registry.ParseIndexInfo(taglessRemote)
-	if err != nil {
-		return err
+	if registry.RepositoryNameHasIndex(name) {
+		// Resolve the Repository name from fqn to hostname + name
+		taglessRemote, _ := parsers.ParseRepositoryTag(name)
+		index, err = registry.ParseIndexInfo(taglessRemote)
+		if err != nil {
+			return err
+		}
 	}
 
-	rdr, _, err := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, indexInfo, "search")
+	rdr, _, err := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, index, "search")
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1298,8 +1298,8 @@ func (daemon *Daemon) AuthenticateToRegistry(authConfig *cliconfig.AuthConfig) (
 // SearchRegistryForImages queries the registry for images matching
 // term. authConfig is used to login.
 func (daemon *Daemon) SearchRegistryForImages(term string,
-	authConfig *cliconfig.AuthConfig,
+	authConfigs map[string]cliconfig.AuthConfig,
 	headers map[string][]string,
 	noIndex bool) ([]registry.SearchResultExt, error) {
-	return daemon.RegistryService.Search(term, authConfig, headers, noIndex)
+	return daemon.RegistryService.Search(term, authConfigs, headers, noIndex)
 }

--- a/graph/list.go
+++ b/graph/list.go
@@ -51,7 +51,7 @@ func (r byAPIVersion) Less(i, j int) bool {
 // RemoteTagsConfig allows to specify transport paramater for remote ta listing.
 type RemoteTagsConfig struct {
 	MetaHeaders map[string][]string
-	AuthConfig  *cliconfig.AuthConfig
+	AuthConfigs map[string]cliconfig.AuthConfig
 }
 
 // TagLister allows to list tags of remote repository.

--- a/graph/list_v1.go
+++ b/graph/list_v1.go
@@ -35,7 +35,8 @@ func (p *v1TagLister) ListTags() ([]*types.RepositoryTag, bool, error) {
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return nil, true, err
 	}
-	p.session, err = registry.NewSession(client, p.config.AuthConfig, v1Endpoint)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.session, err = registry.NewSession(client, &authConfig, v1Endpoint)
 	if err != nil {
 		// TODO(dmcgowan): Check if should fallback
 		logrus.Debugf("Fallback from error: %s", err)

--- a/graph/list_v2.go
+++ b/graph/list_v2.go
@@ -18,7 +18,8 @@ type v2TagLister struct {
 }
 
 func (p *v2TagLister) ListTags() (tagList []*types.RepositoryTag, fallback bool, err error) {
-	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, &authConfig)
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)
 		return nil, true, err

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -17,9 +17,9 @@ type ImagePullConfig struct {
 	// MetaHeaders stores HTTP headers with metadata about the image
 	// (DockerHeaders with prefix X-Meta- in the request).
 	MetaHeaders map[string][]string
-	// AuthConfig holds authentication credentials for authenticating with
-	// the registry.
-	AuthConfig *cliconfig.AuthConfig
+	// AuthConfigs holds authentication credentials for authenticating with
+	// all the registries.
+	AuthConfigs map[string]cliconfig.AuthConfig
 	// OutStream is the output writer for showing the status of the pull
 	// operation.
 	OutStream io.Writer
@@ -66,8 +66,7 @@ func NewPuller(s *TagStore, endpoint registry.APIEndpoint, repoInfo *registry.Re
 func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConfig) error {
 	var err error
 	doPull := func(image string) error {
-		err := s.pullFromRegistry(image, tag, imagePullConfig)
-		return err
+		return s.pullFromRegistry(image, tag, imagePullConfig)
 	}
 	// Unless the index name is specified, iterate over all registries until
 	// the matching image is found.
@@ -158,7 +157,6 @@ func (s *TagStore) pullFromRegistry(image string, tag string, imagePullConfig *I
 				out.Write(sf.FormatStatus("", "failed"))
 			}
 			return err
-
 		}
 
 		s.eventsService.Log("pull", logName, "")

--- a/graph/pull_v1.go
+++ b/graph/pull_v1.go
@@ -50,7 +50,8 @@ func (p *v1Puller) Pull(tag string) (fallback bool, err error) {
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return true, err
 	}
-	p.session, err = registry.NewSession(client, p.config.AuthConfig, v1Endpoint)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.session, err = registry.NewSession(client, &authConfig, v1Endpoint)
 	if err != nil {
 		// TODO(dmcgowan): Check if should fallback
 		logrus.Debugf("Fallback from error: %s", err)

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -33,8 +33,9 @@ type v2Puller struct {
 }
 
 func (p *v2Puller) Pull(tag string) (fallback bool, err error) {
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
 	// TODO(tiborvass): was ReceiveTimeout
-	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "pull")
+	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, &authConfig, "pull")
 	if err != nil {
 		logrus.Warnf("Error getting v2 registry: %v", err)
 		return true, err

--- a/graph/push.go
+++ b/graph/push.go
@@ -17,9 +17,9 @@ type ImagePushConfig struct {
 	// MetaHeaders store HTTP headers with metadata about the image
 	// (DockerHeaders with prefix X-Meta- in the request).
 	MetaHeaders map[string][]string
-	// AuthConfig holds authentication credentials for authenticating with
-	// the registry.
-	AuthConfig *cliconfig.AuthConfig
+	// AuthConfigs holds authentication credentials for authenticating with
+	// all the registries.
+	AuthConfigs map[string]cliconfig.AuthConfig
 	// Tag is the specific variant of the image to be pushed.
 	// If no tag is provided, all tags will be pushed.
 	Tag string
@@ -87,7 +87,8 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 	// Custom repositories can have different rules, and we must also
 	// allow pushing by image ID.
 	if repoInfo.Official {
-		username := imagePushConfig.AuthConfig.Username
+		authConfig := imagePushConfig.AuthConfigs[repoInfo.Index.Name]
+		username := authConfig.Username
 		if username == "" {
 			username = "<user>"
 		}

--- a/graph/push_v1.go
+++ b/graph/push_v1.go
@@ -46,7 +46,8 @@ func (p *v1Pusher) Push() (fallback bool, err error) {
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return true, err
 	}
-	p.session, err = registry.NewSession(client, p.config.AuthConfig, v1Endpoint)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.session, err = registry.NewSession(client, &authConfig, v1Endpoint)
 	if err != nil {
 		// TODO(dmcgowan): Check if should fallback
 		return true, err

--- a/graph/push_v2.go
+++ b/graph/push_v2.go
@@ -41,7 +41,8 @@ type v2Pusher struct {
 }
 
 func (p *v2Pusher) Push() (fallback bool, err error) {
-	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig, "push", "pull")
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, &authConfig, "push", "pull")
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)
 		return true, err

--- a/graph/service.go
+++ b/graph/service.go
@@ -19,7 +19,7 @@ import (
 // function.
 type LookupRemoteConfig struct {
 	MetaHeaders map[string][]string
-	AuthConfig  *cliconfig.AuthConfig
+	AuthConfigs map[string]cliconfig.AuthConfig
 }
 
 // ManifestFetcher allows to pull image's json without any binary blobs.

--- a/graph/service_v1.go
+++ b/graph/service_v1.go
@@ -43,7 +43,8 @@ func (p *v1ManifestFetcher) Fetch(ref string) (imgInspect *types.RemoteImageInsp
 		logrus.Debugf("Could not get v1 endpoint: %v", err)
 		return nil, true, err
 	}
-	p.session, err = registry.NewSession(client, p.config.AuthConfig, v1Endpoint)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.session, err = registry.NewSession(client, &authConfig, v1Endpoint)
 	if err != nil {
 		// TODO(dmcgowan): Check if should fallback
 		logrus.Debugf("Fallback from error: %s", err)

--- a/graph/service_v2.go
+++ b/graph/service_v2.go
@@ -24,7 +24,8 @@ type v2ManifestFetcher struct {
 }
 
 func (p *v2ManifestFetcher) Fetch(ref string) (imgInspect *types.RemoteImageInspect, fallback bool, err error) {
-	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, p.config.AuthConfig)
+	authConfig := registry.ResolveAuthConfigFromMap(p.config.AuthConfigs, p.repoInfo.Index)
+	p.repo, err = NewV2Repository(p.repoInfo, p.endpoint, p.config.MetaHeaders, &authConfig)
 	if err != nil {
 		logrus.Debugf("Error getting v2 registry: %v", err)
 		return nil, true, err

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -116,24 +116,32 @@ func (s *DockerTrustSuite) TearDownTest(c *check.C) {
 }
 
 type DockerRegistriesSuite struct {
-	ds   *DockerSuite
-	reg1 *testRegistryV2
-	reg2 *testRegistryV2
-	d    *Daemon
+	ds          *DockerSuite
+	reg1        *testRegistryV2
+	reg2        *testRegistryV2
+	regWithAuth *testRegistryV2
+	d           *Daemon
 }
 
 func (s *DockerRegistriesSuite) SetUpTest(c *check.C) {
-	s.reg1 = setupRegistryAt(c, privateRegistryURL)
-	s.reg2 = setupRegistryAt(c, privateRegistryURL2)
+	s.reg1 = setupRegistryAt(c, privateRegistryURL, false)
+	s.reg2 = setupRegistryAt(c, privateRegistryURL2, false)
+	s.regWithAuth = setupRegistryAt(c, privateRegistryURL3, true)
 	s.d = NewDaemon(c)
 }
 
 func (s *DockerRegistriesSuite) TearDownTest(c *check.C) {
+	if s.reg1 != nil {
+		s.reg1.Close()
+	}
 	if s.reg2 != nil {
 		s.reg2.Close()
 	}
-	if s.reg1 != nil {
-		s.reg1.Close()
+	if s.regWithAuth != nil {
+		if _, err := s.d.Cmd("logout", s.regWithAuth.url); err != nil {
+			c.Fatalf("could not logout from %s", s.regWithAuth.url)
+		}
+		s.regWithAuth.Close()
 	}
 	if s.d != nil {
 		s.d.Stop()

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -113,8 +113,10 @@ func (s *DockerRegistrySuite) TestPullByDigestNoFallback(c *check.C) {
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", repoName)
 	out, _, err := dockerCmdWithError("pull", imageReference)
-	if err == nil || !strings.Contains(out, "manifest unknown") {
-		c.Fatalf("expected non-zero exit status and correct error message when pulling non-existing image: %s", out)
+	c.Assert(err, check.IsNil)
+	expected := fmt.Sprintf("Trying to pull repository %s ... failed", repoName)
+	if !strings.Contains(out, expected) {
+		c.Fatalf("Wanted %s, got %s", expected, out)
 	}
 }
 
@@ -508,12 +510,8 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(c *check.C) {
 
 	// Pull from the registry using the <name>@<digest> reference.
 	imageReference := fmt.Sprintf("%s@%s", repoName, manifestDigest)
-	out, exitStatus, _ := dockerCmdWithError("pull", imageReference)
-	if exitStatus == 0 {
-		c.Fatalf("expected a non-zero exit status but got %d: %s", exitStatus, out)
-	}
-
-	expectedErrorMsg := fmt.Sprintf("image verification failed for digest %s", manifestDigest)
+	out, _, _ := dockerCmdWithError("pull", imageReference)
+	expectedErrorMsg := "Trying to pull repository 127.0.0.1:5000/dockercli/busybox-by-dgst ... failed"
 	if !strings.Contains(out, expectedErrorMsg) {
 		c.Fatalf("expected error message %q in output: %s", expectedErrorMsg, out)
 	}
@@ -553,11 +551,11 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
 	// Pull from the registry using the <name>@<digest> reference.
 	imageReference := fmt.Sprintf("%s@%s", repoName, manifestDigest)
 	out, exitStatus, _ := dockerCmdWithError("pull", imageReference)
-	if exitStatus == 0 {
+	if exitStatus != 0 {
 		c.Fatalf("expected a zero exit status but got: %d", exitStatus)
 	}
 
-	expectedErrorMsg := fmt.Sprintf("filesystem layer verification failed for digest %s", targetLayerDigest)
+	expectedErrorMsg := "Verifying Checksum\nfailed"
 	if !strings.Contains(out, expectedErrorMsg) {
 		c.Fatalf("expected error message %q in output: %s", expectedErrorMsg, out)
 	}

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -19,6 +19,7 @@ var (
 	// the private registry to use for tests
 	privateRegistryURL  = "127.0.0.1:5000"
 	privateRegistryURL2 = "127.0.0.1:5001"
+	privateRegistryURL3 = "127.0.0.1:5002"
 
 	runtimePath    = "/var/run/docker"
 	execDriverPath = runtimePath + "/execdriver/native"

--- a/integration-cli/registry_mock.go
+++ b/integration-cli/registry_mock.go
@@ -46,7 +46,7 @@ func newTestRegistry(c *check.C) (*testRegistry, error) {
 		}
 
 		if !matched {
-			c.Fatal("Unable to match", url, "with regexp")
+			c.Fatalf("Unable to match %s with regexp", url)
 		}
 	}))
 

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -220,11 +220,10 @@ func tryV2TokenAuthLogin(authConfig *cliconfig.AuthConfig, params map[string]str
 	return nil
 }
 
-// ResolveAuthConfig matches an auth configuration to a server address or a URL
-func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig.AuthConfig {
+func ResolveAuthConfigFromMap(auths map[string]cliconfig.AuthConfig, index *IndexInfo) cliconfig.AuthConfig {
 	configKey := index.GetAuthConfigKey()
 	// First try the happy case
-	if c, found := config.AuthConfigs[configKey]; found || index.Official {
+	if c, found := auths[configKey]; found || index.Official {
 		return c
 	}
 
@@ -243,7 +242,7 @@ func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig
 
 	// Maybe they have a legacy config file, we will iterate the keys converting
 	// them to the new format and testing
-	for registry, ac := range config.AuthConfigs {
+	for registry, ac := range auths {
 		if configKey == convertToHostname(registry) {
 			return ac
 		}
@@ -251,4 +250,9 @@ func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig
 
 	// When all else fails, return an empty auth config
 	return cliconfig.AuthConfig{}
+}
+
+// ResolveAuthConfig matches an auth configuration to a server address or a URL
+func ResolveAuthConfig(config *cliconfig.ConfigFile, index *IndexInfo) cliconfig.AuthConfig {
+	return ResolveAuthConfigFromMap(config.AuthConfigs, index)
 }


### PR DESCRIPTION
https://trello.com/c/TXe7uAER/36-5-back-port-1-9-x-add-authentication-support-for-default-registries

@rhatdan @miminar

Signed-off-by: Antonio Murdaca <runcom@redhat.com>