### PR TITLE
Make range checking of loginuid values 32-bit safe

### DIFF
--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -215,7 +215,7 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
 			break
 		}
 		message = fmt.Sprintf("LoginUID=%v, %s", loginuid, message)
-		if loginuid == 0xffffffff { // -1 means no login user
+		if loginuid < 0 || uint32(loginuid) >= 0xffffffff { // -1 means no login user
 			//No login UID is set, so no point in looking up a name
 			break
 		}


### PR DESCRIPTION
When we check that the loginuid value that we read is a meaningful
value, do it in a way that doesn't overflow 32-bit builds at build-time.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>