### PR TITLE
Updates for OS-specific builds

### DIFF
--- a/contrib/builder/rpm/centos-7/Dockerfile
+++ b/contrib/builder/rpm/centos-7/Dockerfile
@@ -4,14 +4,26 @@
 
 FROM centos:7
 
+ENV DOCKER_CROSSPLATFORMS \
+        linux/386 linux/arm \
+        darwin/amd64 \
+        freebsd/amd64 freebsd/386 freebsd/arm \
+        windows/amd64 windows/386
+
+ENV GOARM 5
+
 RUN yum groupinstall -y "Development Tools"
 RUN yum -y swap -- remove systemd-container systemd-container-libs -- install systemd systemd-libs
-RUN yum install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-ENV PATH $PATH:/usr/local/go/bin
+ENV PATH /usr/local/go/bin:$PATH
 
-ENV AUTO_GOPATH 1
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 ENV DOCKER_BUILDTAGS selinux
+
+WORKDIR /go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker

--- a/contrib/builder/rpm/fedora-22/Dockerfile
+++ b/contrib/builder/rpm/fedora-22/Dockerfile
@@ -4,10 +4,18 @@
 
 FROM fedora:22
 
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ENV DOCKER_CROSSPLATFORMS \
+        linux/386 linux/arm \
+        darwin/amd64 \
+        freebsd/amd64 freebsd/386 freebsd/arm \
+        windows/amd64 windows/386
 
-ENV SECCOMP_VERSION v2.2.3
+ENV GOARM 5
+
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION 2.2.3
 RUN buildDeps=' \
 automake \
 libtool \
@@ -15,7 +23,7 @@ libtool \
 && set -x \
 && yum install -y $buildDeps \
 && export SECCOMP_PATH=$(mktemp -d) \
-&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& git clone -b v"$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
 && ( \
 cd "$SECCOMP_PATH" \
 && ./autogen.sh \
@@ -30,8 +38,12 @@ cd "$SECCOMP_PATH" \
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-ENV PATH $PATH:/usr/local/go/bin
+ENV PATH /usr/local/go/bin:$PATH
 
-ENV AUTO_GOPATH 1
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 ENV DOCKER_BUILDTAGS seccomp selinux
+
+WORKDIR /go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker

--- a/contrib/builder/rpm/fedora-23/Dockerfile
+++ b/contrib/builder/rpm/fedora-23/Dockerfile
@@ -4,10 +4,18 @@
 
 FROM fedora:23
 
-RUN dnf install -y @development-tools fedora-packager
-RUN dnf install -y btrfs-progs-devel device-mapper-devel glibc-static libaudit-dev libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ENV DOCKER_CROSSPLATFORMS \
+        linux/386 linux/arm \
+        darwin/amd64 \
+        freebsd/amd64 freebsd/386 freebsd/arm \
+        windows/amd64 windows/386
 
-ENV SECCOMP_VERSION v2.2.3
+ENV GOARM 5
+
+RUN dnf install -y @development-tools fedora-packager
+RUN dnf install -y audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static libseccomp-devel libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+
+ENV SECCOMP_VERSION 2.2.3
 RUN buildDeps=' \
 automake \
 libtool \
@@ -15,7 +23,7 @@ libtool \
 && set -x \
 && yum install -y $buildDeps \
 && export SECCOMP_PATH=$(mktemp -d) \
-&& git clone -b "$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
+&& git clone -b v"$SECCOMP_VERSION" --depth 1 https://github.com/seccomp/libseccomp.git "$SECCOMP_PATH" \
 && ( \
 cd "$SECCOMP_PATH" \
 && ./autogen.sh \
@@ -30,8 +38,12 @@ cd "$SECCOMP_PATH" \
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-ENV PATH $PATH:/usr/local/go/bin
+ENV PATH /usr/local/go/bin:$PATH
 
-ENV AUTO_GOPATH 1
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 ENV DOCKER_BUILDTAGS seccomp selinux
+
+WORKDIR /go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker

--- a/contrib/builder/rpm/opensuse-13.2/Dockerfile
+++ b/contrib/builder/rpm/opensuse-13.2/Dockerfile
@@ -4,13 +4,25 @@
 
 FROM opensuse:13.2
 
-RUN zypper --non-interactive install ca-certificates* curl gzip rpm-build
-RUN zypper --non-interactive install libaudit-dev libbtrfs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+ENV DOCKER_CROSSPLATFORMS \
+        linux/386 linux/arm \
+        darwin/amd64 \
+        freebsd/amd64 freebsd/386 freebsd/arm \
+        windows/amd64 windows/386
+
+ENV GOARM 5
+
+RUN zypper --non-interactive install ca-certificates* curl git gzip rpm-build
+RUN zypper --non-interactive install audit-devel libbtrfs-devel device-mapper-devel glibc-devel-static  libselinux-devel libtool selinux-policy selinux-policy-devel sqlite3-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-ENV PATH $PATH:/usr/local/go/bin
+ENV PATH /usr/local/go/bin:$PATH
 
-ENV AUTO_GOPATH 1
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 ENV DOCKER_BUILDTAGS selinux
+
+WORKDIR /go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker

--- a/contrib/builder/rpm/oraclelinux-7/Dockerfile
+++ b/contrib/builder/rpm/oraclelinux-7/Dockerfile
@@ -4,13 +4,25 @@
 
 FROM oraclelinux:7
 
+ENV DOCKER_CROSSPLATFORMS \
+        linux/386 linux/arm \
+        darwin/amd64 \
+        freebsd/amd64 freebsd/386 freebsd/arm \
+        windows/amd64 windows/386
+
+ENV GOARM 5
+
 RUN yum groupinstall -y "Development Tools"
-RUN yum install -y --enablerepo=ol7_optional_latest btrfs-progs-devel device-mapper-devel glibc-static  libaudit-dev libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
+RUN yum install -y --enablerepo=ol7_optional_latest audit-libs-devel audit-libs-static btrfs-progs-devel device-mapper-devel glibc-static  libselinux-devel libtool-ltdl-devel selinux-policy selinux-policy-devel sqlite-devel tar
 
 ENV GO_VERSION 1.5.3
 RUN curl -fSL "https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz" | tar xzC /usr/local
-ENV PATH $PATH:/usr/local/go/bin
+ENV PATH /usr/local/go/bin:$PATH
 
-ENV AUTO_GOPATH 1
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 
 ENV DOCKER_BUILDTAGS selinux
+
+WORKDIR /go/src/github.com/docker/docker
+
+COPY . /go/src/github.com/docker/docker


### PR DESCRIPTION
* Check out the right branch of libseccomp
* Put the go compiler that we download in the front of $PATH
* Copy the docker source tree into the build container
* Set GOPATH to point to docker before the golang sources
* Set a WORKDIR
* Commit changes to generated files

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>