### PR TITLE
Fix login to docker.io on *-1.9 branches

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -39,7 +39,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		cli.in = os.Stdin
 	}
 
-	serverAddress := registry.IndexServerName()
+	serverAddress := registry.IndexServerAddress()
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -19,7 +19,7 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	serverAddress := registry.IndexServerName()
+	serverAddress := registry.IndexServerAddress()
 	if len(cmd.Args()) > 0 {
 		serverAddress = cmd.Arg(0)
 	}

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -36,7 +36,7 @@ func loginV1(authConfig *cliconfig.AuthConfig, registryEndpoint *Endpoint) (stri
 		return "", fmt.Errorf("Server Error: Server Address not set.")
 	}
 
-	loginAgainstOfficialIndex := serverAddress == IndexServerName()
+	loginAgainstOfficialIndex := serverAddress == IndexServer
 
 	// to avoid sending the server address to the server it should be removed before being marshalled
 	authCopy := *authConfig


### PR DESCRIPTION
Fix this bz: https://bugzilla.redhat.com/show_bug.cgi?id=1289963

With my latest auth patch to registries when pushing/pulling we clearly exposed a small bug which prevents pushing to docker.io after a docker login for instance:
Patch which introduced this behavior: https://github.com/projectatomic/docker/commit/f4b87f52db74cf8f88a87fe61ba74cd8395edb69

@miminar could you take a fast look at this since you wrote that so I'm sure about this?

@rhatdan I'll ask Lokesh to rebuild after you merge

Signed-off-by: Antonio Murdaca <runcom@redhat.com>