### PR TITLE
remove unused argument

### DIFF
--- a/api/server/router/build/build_routes.go
+++ b/api/server/router/build/build_routes.go
@@ -254,7 +254,7 @@ func (br *buildRouter) postBuild(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	for _, rt := range repoAndTags {
-		if err := br.backend.TagImage(rt, imgID, true); err != nil {
+		if err := br.backend.TagImage(rt, imgID); err != nil {
 			return errf(err)
 		}
 	}

--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -374,7 +374,7 @@ func (s *router) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 			return err
 		}
 	}
-	if err := s.daemon.TagImage(newTag, vars["name"], true); err != nil {
+	if err := s.daemon.TagImage(newTag, vars["name"]); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusCreated)

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -199,7 +199,7 @@ func (daemon *Daemon) Commit(name string, c *types.ContainerCommitConfig) (strin
 				return "", err
 			}
 		}
-		if err := daemon.TagImage(newTag, id.String(), true); err != nil {
+		if err := daemon.TagImage(newTag, id.String()); err != nil {
 			return "", err
 		}
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -952,7 +952,7 @@ func (daemon *Daemon) changes(container *container.Container) ([]archive.Change,
 
 // TagImage creates a tag in the repository reponame, pointing to the image named
 // imageName.
-func (daemon *Daemon) TagImage(newTag reference.Named, imageName string, keepUnqualified bool) error {
+func (daemon *Daemon) TagImage(newTag reference.Named, imageName string) error {
 	imageID, err := daemon.GetImageID(imageName)
 	if err != nil {
 		return err

--- a/daemon/import.go
+++ b/daemon/import.go
@@ -92,7 +92,7 @@ func (daemon *Daemon) ImportImage(src string, newRef reference.Named, msg string
 
 	// FIXME: connect with commit code and call refstore directly
 	if newRef != nil {
-		if err := daemon.TagImage(newRef, id.String(), true); err != nil {
+		if err := daemon.TagImage(newRef, id.String()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
@miminar I just need to know if this change is good because I'm integrating this fix in a follow up PR to add auth to default registries in 1.10...

DO NOT MERGE NOR IMPORT THIS PATCH

Signed-off-by: Antonio Murdaca <runcom@redhat.com>