### PR TITLE
Set correct authConfig key in authConfigs map

### DIFF
--- a/api/server/router/local/image.go
+++ b/api/server/router/local/image.go
@@ -630,7 +630,8 @@ func (s *router) getAuthConfigs(name string, r *http.Request, backward bool, sea
 			}
 		}
 		// this is the case when we fully qualify images
-		authConfigs[repoInfo.Index.Name] = authConfig
+		authConfigKey := repoInfo.Index.GetAuthConfigKey()
+		authConfigs[authConfigKey] = authConfig
 	}
 
 	return authConfigs, nil


### PR DESCRIPTION
I found this bug while working on adding auths for default registries in *-1.10 branches, so fix for *-1.10 will come as soon as I finish my work.

This needs to be applied also on `fedora-1.9` branch

@miminar PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>