### PR TITLE
daemon: add no-volumes flag

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -37,6 +37,7 @@ type CommonConfig struct {
 	BlockedRegistries    []string
 	AdditionalRegistries []string
 	ConfirmDefPush       bool
+	NoVolumes            bool
 
 	// ClusterStore is the storage backend used for the cluster information. It is used by both
 	// multihost networking (to store networks and endpoints information) and by the node discovery
@@ -80,4 +81,5 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.Var(opts.NewListOptsRef(&config.BlockedRegistries, nil), []string{"-block-registry"}, usageFn("Don't contact given registry"))
 	cmd.Var(opts.NewListOptsRef(&config.AdditionalRegistries, nil), []string{"-add-registry"}, usageFn("Registry to query before a public one"))
 	cmd.BoolVar(&config.ConfirmDefPush, []string{"-confirm-def-push"}, true, usageFn("Confirm a push to default registry"))
+	cmd.BoolVar(&config.NoVolumes, []string{"#-no-volumes"}, false, usageFn("Do not run containers with volumes"))
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -271,6 +271,10 @@ func (container *Container) Start() (err error) {
 		return derr.ErrorCodeContainerBeingRemoved
 	}
 
+	if err := container.checkNoVolumes(); err != nil {
+		return err
+	}
+
 	// if we encounter an error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -208,3 +208,7 @@ func (container *Container) cleanupSecrets() {
 func (container *Container) setupSecretFiles() error {
 	return nil
 }
+
+func (container *Container) checkNoVolumes() error {
+	return nil
+}

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1853,3 +1853,98 @@ func (s *DockerDaemonSuite) TestDaemonStartWithDefalutTlsHost(c *check.C) {
 		c.Fatalf("docker version should return information of server side")
 	}
 }
+
+func (s *DockerDaemonSuite) TestDaemonStartWithNoVolumes(c *check.C) {
+	c.Assert(s.d.StartWithBusybox("--no-volumes"), checker.IsNil)
+
+	dockerfile, cleanup, err := makefile("FROM busybox\nVOLUME novolume")
+	c.Assert(err, check.IsNil, check.Commentf("Unable to create test dockerfile"))
+	defer cleanup()
+	imgName := "novolume"
+	_, err = s.d.Cmd("build", "-t", imgName, "--file", dockerfile, ".")
+	c.Assert(err, checker.IsNil)
+
+	out, err := s.d.Cmd("run", imgName)
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+
+	testCommitName := "commit-with-volume"
+	_, err = s.d.Cmd("run", "--name", testCommitName, "busybox", "true")
+	c.Assert(err, check.IsNil)
+	out, err = s.d.Cmd("commit", "--change", "VOLUME test", testCommitName, testCommitName+"-commit")
+	c.Assert(err, check.IsNil)
+
+	out, err = s.d.Cmd("run", testCommitName+"-commit")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+}
+
+func (s *DockerDaemonSuite) TestDaemonStartWithNoVolumesFalse(c *check.C) {
+	c.Assert(s.d.StartWithBusybox("--no-volumes=false"), checker.IsNil)
+
+	dockerfile, cleanup, err := makefile("FROM busybox\nVOLUME test")
+	c.Assert(err, check.IsNil, check.Commentf("Unable to create test dockerfile"))
+	defer cleanup()
+	imgName := "volume"
+	_, err = s.d.Cmd("build", "-t", imgName, "--file", dockerfile, ".")
+	c.Assert(err, checker.IsNil)
+
+	out, err := s.d.Cmd("run", imgName)
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "volumes are not allowed")
+
+	testCommitName := "commit-with-volume"
+	_, err = s.d.Cmd("run", "--name", testCommitName, "busybox", "true")
+	c.Assert(err, check.IsNil)
+	_, err = s.d.Cmd("commit", "--change", "VOLUME volume", testCommitName, testCommitName+"-commit")
+	c.Assert(err, check.IsNil)
+
+	out, err = s.d.Cmd("run", testCommitName+"-commit")
+	c.Assert(err, checker.IsNil)
+}
+
+// create, as build, will continue to work, we error out on run only
+func (s *DockerDaemonSuite) TestDaemonStartWithNoVolumesNoRunVolumes(c *check.C) {
+	c.Assert(s.d.StartWithBusybox("--no-volumes"), checker.IsNil)
+
+	out, err := s.d.Cmd("run", "-v", "/test", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+
+	out, err = s.d.Cmd("create", "-v", "/test", "busybox", "true")
+	c.Assert(err, checker.IsNil)
+
+	volName := "avolume"
+	_, err = s.d.Cmd("volume", "create", "--name", volName)
+	c.Assert(err, checker.IsNil)
+	out, err = s.d.Cmd("run", "-v", volName+":/test", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+
+	out, err = s.d.Cmd("run", "-v", "will-be-created:/test", "busybox", "true")
+	c.Assert(err, checker.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+
+	tmpDir, err := ioutil.TempDir("", "test")
+	c.Assert(err, check.IsNil)
+	f := filepath.Join(tmpDir, "file")
+	c.Assert(ioutil.WriteFile(f, []byte("foobar"), 0644), check.IsNil)
+
+	out, err = s.d.Cmd("run", "-v", tmpDir+":/test/", "busybox", "cat", "/test/file")
+	c.Assert(err, checker.IsNil, check.Commentf(out))
+	c.Assert(out, checker.Not(checker.Contains), "volumes are not allowed")
+	c.Assert(out, checker.Contains, "foobar")
+}
+
+func (s *DockerDaemonSuite) TestDaemonStartWithNoVolumesNoVolumesFrom(c *check.C) {
+	c.Assert(s.d.StartWithBusybox("--no-volumes=false"), checker.IsNil)
+
+	_, err := s.d.Cmd("run", "--name=vfrom", "-v", "/test", "busybox", "true")
+	c.Assert(err, check.IsNil)
+
+	c.Assert(s.d.Restart("--no-volumes=true"), checker.IsNil)
+
+	out, err := s.d.Cmd("run", "--volumes-from=vfrom", "busybox", "true")
+	c.Assert(err, check.NotNil)
+	c.Assert(out, checker.Contains, "volumes are not allowed")
+}


### PR DESCRIPTION
Prevents running containers with volumes. This patch will block running
containers from images built with VOLUME(s) instructions. It will also
block running cotainers that define a volume (docker run -v). docker
create -v won't error out instead. Running with --volumes-from is
forbidden also.
This patch adds a --no-volumes flag to the docker daemon which prevents
what said above. The feature is opt-in, otherwise the engine will run
as it was.
This will allow operators to allow users to use their own images but
want to control where users can write.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>