### PR TITLE
daemon_unix: set golang runtime max threads

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -672,6 +672,10 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 	logrus.Debugf("Using default logging driver %s", config.LogConfig.Type)
 
+	if err := configureMaxThreads(config); err != nil {
+		logrus.Warnf("Failed to configure golang's threads limit: %v", err)
+	}
+
 	daemonRepo := filepath.Join(config.Root, "containers")
 	if err := idtools.MkdirAllAs(daemonRepo, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return nil, err

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -4,10 +4,12 @@ package daemon
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"syscall"
@@ -461,6 +463,23 @@ func checkSystem() error {
 		return fmt.Errorf("The Docker daemon needs to be run as root")
 	}
 	return checkKernel()
+}
+
+// configureMaxThreads sets the Go runtime max threads threshold
+// which is 90% of the kernel setting from /proc/sys/kernel/threads-max
+func configureMaxThreads(config *Config) error {
+	mt, err := ioutil.ReadFile("/proc/sys/kernel/threads-max")
+	if err != nil {
+		return err
+	}
+	mtint, err := strconv.Atoi(strings.TrimSpace(string(mt)))
+	if err != nil {
+		return err
+	}
+	maxThreads := (mtint / 100) * 90
+	debug.SetMaxThreads(maxThreads)
+	logrus.Debugf("Golang's threads limit set to %d", maxThreads)
+	return nil
 }
 
 // configureKernelSecuritySupport configures and validate security support for the kernel

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -115,6 +115,11 @@ func configureKernelSecuritySupport(config *Config, driverName string) error {
 	return nil
 }
 
+// configureMaxThreads sets the Go runtime max threads threshold
+func configureMaxThreads(config *Config) error {
+	return nil
+}
+
 func isBridgeNetworkDisabled(config *Config) bool {
 	return false
 }


### PR DESCRIPTION
SetMaxThreads from runtime/debug in Golang is called to set max threads
value to 90% of /proc/sys/kernel/threads-max

Signed-off-by: Antonio Murdaca <runcom@redhat.com>