### PR TITLE
Bug 1300076 - SIGPIPE events kill go process

### DIFF
--- a/contrib/forward-journald/forward-journald.go
+++ b/contrib/forward-journald/forward-journald.go
@@ -1,0 +1,84 @@
+// Main package for forward-journald
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/coreos/go-systemd/journal"
+)
+
+var pgrep_filter = flag.String("filter", "", "pgrep filter to determine process to forward")
+var pri_info = flag.Bool("1", true, "forward stdin to journald as Priority Informational")
+var pri_error = flag.Bool("2", false, "forward stdin to journald as Priority Error")
+
+func init() {
+	flag.StringVar(pgrep_filter, "f", "", "pgrep filter to determine process to forward")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %v:\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  %v --filter docker\n\n", path.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+}
+
+func main() {
+	flag.Parse()
+	if *pgrep_filter == "" {
+		fmt.Fprintln(os.Stderr, "-filter option required.")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	forwarded_pid, err := GetProcess(*pgrep_filter)
+	if forwarded_pid == "" {
+		fmt.Fprintln(os.Stderr, "unable to find process from pgrep filter: %v", *pgrep_filter)
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	if journal.Enabled() {
+		journal.Send(fmt.Sprintf("Forwarding %v[%v] output to journald", *pgrep_filter, forwarded_pid), journal.PriInfo, nil)
+	} else {
+		fmt.Fprintln(os.Stderr, "forward-journald: Unable to connect to journald")
+		os.Exit(3)
+	}
+
+	var fields map[string]string = nil
+
+	if len(forwarded_pid) > 0 {
+		fields = map[string]string{
+			"OBJECT_PID": forwarded_pid,
+		}
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+
+	var priority journal.Priority
+	if *pri_error {
+		priority = journal.PriErr
+	} else {
+		priority = journal.PriInfo
+	}
+
+	var line string = ""
+	for err == nil {
+		line, err = reader.ReadString('\n')
+
+		if journal.Enabled() {
+			if err == nil {
+				line = strings.TrimSpace(line)
+				journal.Send(line, priority, fields)
+			} else {
+				// log any partial lines
+				if len(line) > 0 {
+					journal.Send(line, priority, fields)
+				}
+			}
+		}
+	}
+}

--- a/contrib/forward-journald/forward-journald.man
+++ b/contrib/forward-journald/forward-journald.man
@@ -1,0 +1,74 @@
+.TH FORWARD-JOURNALD 8 2016-02-29 REDHAT "System Manager's Manual"
+.SH NAME
+forward-journald \- forward stdin to journald
+.SH SYNOPSIS
+.B forward-journald
+[\fIOPTION\fR]...
+.SH DESCRIPTION
+Forward lines received from stdin to journald
+.SH OPTIONS
+.TP
+.B -1
+Use the priority of informational when writing to journald (default)
+.TP
+.B -2
+Use the priority of error when writing to journald
+.TP
+.BI -filter= NAME
+Use the argument
+.I NAME
+to determine which process is being fowarded
+.SH "EXIT STATUS"
+.TP
+0
+No errors occurred
+.TP
+1
+Bad/Missing options on command line
+.TP
+2
+Unable to find process to be forwarded. Process to be forwarded may have died on startup.
+.TP
+3
+Unable to connect to journald.
+.SH NOTES
+Workaround for
+.BR SIGPIPE
+issue with < go 1.6rc2, where writing 10 times to stdout or stderr will cause the
+.BR SIGPIPE
+events to be
+converted to a non-trappable
+.BR SIGPIPE
+killing any process written in
+.BR go(1).
+.SH BUGS
+Docker command crashes after journald is stopped (https://bugzilla.redhat.com/show_bug.cgi?id=1300076)
+.SH "EXAMPLE"
+Update docker.service to guard
+.BR docker(1)
+from the
+.BR SIGPIPE
+issue:
+.SS "docker.service"
+.nf
+:
+[Service]
+Type=notify
+NotifyAccess=all
+ExecStart=/bin/sh -c '/usr/bin/docker daemon \\
+          $OPTIONS \\
+          $DOCKER_STORAGE_OPTIONS \\
+          $DOCKER_NETWORK_OPTIONS \\
+          $INSECURE_REGISTRY \\
+          2>&1 | /usr/bin/forward-journald'
+StandardOutput=null
+StandardError=null
+:
+.fi
+.SH "SEE ALSO"
+.BR go(1),
+.BR docker(1),
+.BR systemd(1),
+.BR journald(1)
+.BR systemd-journald(8),
+

--- a/contrib/forward-journald/proc.go
+++ b/contrib/forward-journald/proc.go
@@ -1,0 +1,23 @@
+// Main package for forward-journald
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+)
+
+// GetProcess uses the system command pgrep to determine the pid for the process name given
+// It returns the pid or any error reported by os/exec.Command.Run()
+func GetProcess(filter string) (string, error) {
+	var out bytes.Buffer
+	command := exec.Command("pgrep", filter)
+	command.Stdout = &out
+
+	err := command.Run()
+	if err == nil {
+		return strings.TrimSpace(out.String()), err
+	} else {
+		return "", err
+	}
+}


### PR DESCRIPTION
Add command forward-journald to forward stdin to journald.

Note:
THis workaround is to address the issue in < go 1.6rc2 where
10 SIGPIPE events cause the go process to be killed.
signal.Notify() is ignored by the go libraries in this special case.

Signed-off-by: Jhon Honce <jhonce@redhat.com>