### PR TITLE
Set Delegate=yes for cgroup transient units

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -159,6 +159,7 @@ func (m *Manager) Apply(pid int) error {
 		systemdDbus.PropSlice(slice),
 		systemdDbus.PropDescription("docker container "+c.Name),
 		newProp("PIDs", []uint32{uint32(pid)}),
+		newProp("Delegate", true),
 	)
 
 	// Always enable accounting, this gets us the same behaviour as the fs implementation,


### PR DESCRIPTION
Ported this fix to fedora-1.9 branch.

@runcom @rhatdan PTAL

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>