### PR TITLE
The following syscalls should not be blocked by seccomp

### DIFF
--- a/daemon/execdriver/native/seccomp_default.go
+++ b/daemon/execdriver/native/seccomp_default.go
@@ -1634,5 +1634,30 @@ var defaultSeccompProfile = &configs.Seccomp{
 			Action: configs.Allow,
 			Args:   []*configs.Arg{},
 		},
+		{
+			Name:   "mount",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "umount2",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "reboot",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "name_to_handle_at",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
+		{
+			Name:   "unshare",
+			Action: configs.Allow,
+			Args:   []*configs.Arg{},
+		},
 	},
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"
-->

Please provide the following information:

- What did you do?

- How did you do it?

- How do I see it or verify it?

- A picture of a cute animal (not mandatory but encouraged)


Capabilities block these syscalls.

mount, umount2, unshare, reboot and name_to_handle_at are all needed to
run systemd as pid1 in a container, they work fine with sys_admin disabled
and have functionality in the kernel that is available to a non privileged
process.  There is no easy way to discover which syscalls are blocked, so
we end up more likely with the user doing a --privileged.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>