### PR TITLE
api: server: credentials_linux: fix wrong uid parsing

### DIFF
--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -92,7 +92,8 @@ func getLoginUID(ucred *syscall.Ucred, fd int) (int64, error) {
 
 //Given a loginUID, retrieves the current username
 func getpwuid(loginUID uint32) (string, error) {
-	pwd, err := user.LookupId(string(loginUID))
+	uid := strconv.FormatUint(uint64(loginUID), 10)
+	pwd, err := user.LookupId(uid)
 	if err != nil {
 		logrus.Errorf("Failed to get pwuid struct: %v", err)
 		return "", err


### PR DESCRIPTION
solves those logs:

Mar 23 15:46:57 localhost.localdomain docker[30043]:
time="2016-03-23T15:46:57.097702190+01:00" level=error msg="Failed to
get pwuid struct: strconv.ParseInt: parsing \"橌\": invalid syntax"

Failed to get pwuid struct: strconv.ParseInt: parsing \"Ϩ\": invalid
syntax

Signed-off-by: Antonio Murdaca <runcom@redhat.com>