### PR TITLE
BACKPORT: Add additional debug information to cgroup writes

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/fs/apply_raw.go
@@ -287,7 +287,10 @@ func writeFile(dir, file, data string) error {
 	if dir == "" {
 		return fmt.Errorf("no such directory for %s.", file)
 	}
-	return ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700)
+	if err := ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700); err != nil {
+		return fmt.Errorf("error writing %v to %v: %v", data, file, err)
+	}
+	return nil
 }
 
 func readFile(dir, file string) (string, error) {


### PR DESCRIPTION
@runcom @rhatdan Ported to Fedora 1.9


Signed-off-by: Mrunal Patel <mrunalp@gmail.com>