### PR TITLE
BACKPORT: Inherit StopSignal from Dockerfile.

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -89,6 +89,9 @@ func merge(userConf, imageConf *containertypes.Config) error {
 			userConf.Volumes[k] = v
 		}
 	}
+	if userConf.StopSignal == "" {
+		userConf.StopSignal = imageConf.StopSignal
+	}
 	return nil
 }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5891,15 +5891,22 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 
 func (s *DockerSuite) TestBuildStopSignal(c *check.C) {
 	testRequires(c, DaemonIsLinux)
-	name := "test_build_stop_signal"
-	_, err := buildImage(name,
+	imgName := "test_build_stop_signal"
+	_, err := buildImage(imgName,
 		`FROM busybox
 		 STOPSIGNAL SIGKILL`,
 		true)
 	c.Assert(err, check.IsNil)
-	res, err := inspectFieldJSON(name, "Config.StopSignal")
+	res, err := inspectFieldJSON(imgName, "Config.StopSignal")
 	c.Assert(err, check.IsNil)
+	if res != `"SIGKILL"` {
+		c.Fatalf("Signal %s, expected SIGKILL", res)
+	}
 
+	containerName := "test-container-stop-signal"
+	dockerCmd(c, "run", "-d", "--name", containerName, imgName, "top")
+	res, err = inspectFieldJSON(containerName, "Config.StopSignal")
+	c.Assert(err, check.IsNil)
 	if res != `"SIGKILL"` {
 		c.Fatalf("Signal %s, expected SIGKILL", res)
 	}

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -375,7 +375,10 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 		Labels:          ConvertKVStringsToMap(labels),
-		StopSignal:      *flStopSignal,
+	}
+
+	if cmd.IsSet("-stop-signal") {
+		config.StopSignal = *flStopSignal
 	}
 
 	hostConfig := &container.HostConfig{


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1201657

Upstream reference:
https://github.com/docker/docker/pull/20290/commits/a252516ec19c9c83055a882da894712f2e812ecc

Make sure the image configuration is not overriden by the default
value in the `create` flag.

Signed-off-by: Antonio Murdaca <runcom@redhat.com>