### PR TITLE
Ignore invalid host header between go1.6 and <= go1.4

### DIFF
--- a/docker/listeners/listeners_unix.go
+++ b/docker/listeners/listeners_unix.go
@@ -33,7 +33,7 @@ func Init(proto, addr, socketGroup string, tlsConfig *tls.Config) (ls []net.List
 		if err != nil {
 			return nil, fmt.Errorf("can't create unix socket %s: %v", addr, err)
 		}
-		ls = append(ls, l)
+		ls = append(ls, &MalformedHostHeaderOverride{l})
 	default:
 		return nil, fmt.Errorf("Invalid protocol format: %q", proto)
 	}

--- a/docker/listeners/malformed_host_override.go
+++ b/docker/listeners/malformed_host_override.go
@@ -1,0 +1,85 @@
+// +build !windows
+
+package listeners
+
+import (
+	"net"
+	"strings"
+)
+
+// MalformedHostHeaderOverride is a wrapper to be able
+// to overcome the 400 Bad request coming from old docker
+// clients that send an invalid Host header.
+type MalformedHostHeaderOverride struct {
+	net.Listener
+}
+
+// MalformedHostHeaderOverrideConn wraps the underlying unix
+// connection and keeps track of the first read from http.Server
+// which just reads the headers.
+type MalformedHostHeaderOverrideConn struct {
+	net.Conn
+	first bool
+}
+
+// Read reads the first *read* request from http.Server to inspect
+// the Host header. If the Host starts with / then we're talking to
+// an old docker client which send an invalid Host header. To not
+// error out in http.Server we rewrite the first bytes of the request
+// to sanitize the Host header itself.
+// In case we're not dealing with old docker clients the data is just passed
+// to the server w/o modification.
+func (l *MalformedHostHeaderOverrideConn) Read(b []byte) (n int, err error) {
+	// http.Server uses a 4k buffer
+	if l.first && len(b) == 4096 {
+		// This keeps track of the first read from http.Server which just reads
+		// the headers
+		l.first = false
+		// The first read of the connection by http.Server is done limited to
+		// DefaultMaxHeaderBytes (usually 1 << 20) + 4096.
+		// Here we do the first read which gets us all the http headers to
+		// be inspected and modified below.
+		c, err := l.Conn.Read(b)
+		if err != nil {
+			return c, err
+		}
+		parts := strings.Split(string(b[:c]), "\n")
+		head := []string{parts[0]}
+		if len(parts) > 0 {
+			if !strings.HasPrefix(parts[1], "Host:") {
+				// old docker clients sends the Host header at parts[1]
+				// which is the second line of the http request
+				// if we're not talking to an old docker client, just skip
+				head = parts
+			} else if !strings.HasPrefix(parts[1], "Host: /") {
+				// we're talking to a newer docker clients if Host doesn't start
+				// with a slash
+				head = parts
+			} else {
+				// we're now talking to an old docker client
+				// Sanitize Host header
+				head = append(head, "Host: \r")
+				// Inject `Connection: close` to ensure we don't reuse this connection
+				head = append(head, "Connection: close\r")
+				// append the remaining headers
+				if len(parts) > 1 {
+					head = append(head, parts[2:]...)
+				}
+			}
+		}
+		newHead := strings.Join(head, "\n")
+		copy(b, []byte(newHead))
+		return len(newHead), nil
+	}
+	return l.Conn.Read(b)
+}
+
+// Accept makes the listener accepts connections and wraps the connection
+// in a MalformedHostHeaderOverrideConn initilizing first to true.
+func (l *MalformedHostHeaderOverride) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return c, err
+	}
+	return &MalformedHostHeaderOverrideConn{c, true}, nil
+}


### PR DESCRIPTION
Fix BZ1324150 (https://bugzilla.redhat.com/show_bug.cgi?id=1324150)

**In case this will be merged we'll need to patch `fedora-1.11` branch and probably 1.10.3 docker branches if we're going to build 1.10.3 with go1.6**

@rhatdan @eparis PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>