### PR TITLE
Skip /dev setup in container when it is bind mounted in

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -280,6 +280,7 @@ func (d *Driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 	for _, m := range container.Mounts {
 		if _, ok := userMounts[m.Destination]; !ok {
 			if mountDev && strings.HasPrefix(m.Destination, "/dev/") {
+				container.Devices = nil
 				continue
 			}
 			defaultMounts = append(defaultMounts, m)


### PR DESCRIPTION
@mrunalp @eparis @rhatdan _could_ fix https://bugzilla.redhat.com/show_bug.cgi?id=1329326