### PR TITLE
BACKPORT: Fixes for --cgroup-parent slices to expand correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ https://github.com/docker/docker/pull/22009
 
 https://github.com/docker/docker/pull/22069
 
+#### BACKPORT:-Properly-expand-systemd-slice-names.patch
+
+https://github.com/opencontainers/runc/pull/511
+
 #### Ignore-invalid-host-header-between-go1.6-and-old-docker-clients.patch
 
 https://bugzilla.redhat.com/show_bug.cgi?id=1324150


### PR DESCRIPTION
This fix was missing in docker-latest package.


Signed-off-by: Mrunal Patel <mrunalp@gmail.com>