### PR TITLE
Bug 1300076 - SIGPIPE events kill go process

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/client"
@@ -18,6 +20,14 @@ func main() {
 	if reexec.Init() {
 		return
 	}
+
+	go func() {
+		c := make(chan os.Signal, 2048)
+		signal.Notify(c, os.Signal(syscall.SIGPIPE))
+		for {
+			<- c
+		}
+	}()
 
 	// Set terminal emulation based on platform as required.
 	stdin, stdout, stderr := term.StdStreams()


### PR DESCRIPTION
Using golang 1.6, is it now possible to ignore SIGPIPE events on
stdout/stderr.  Previous versions of the golang library cached 10
events and then killed the process receiving the events.

systemd-journald sends SIGPIPE events when journald is restarted and the
target of the unit file writes to stdout/stderr.  Docker logs to stdout/stderr.

This patch silently ignores all SIGPIPE events.

Signed-off-by: Jhon Honce <jhonce@redhat.com>