### PR TITLE
Fix audit patch

### DIFF
--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -234,14 +234,7 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
 	}
 	message = fmt.Sprintf("{Action=%v, %s}", action, message)
 	switch action {
-	case "info":
-	case "images":
-	case "version":
-	case "json":
-	case "search":
-	case "stats":
-	case "events":
-	case "history":
+	case "history", "info", "images", "version", "json", "search", "stats", "events":
 		logrus.Debug(message)
 		fallthrough
 	default:
@@ -253,53 +246,47 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
 
 //Logs an API event to the audit log
 func logAuditlog(c *daemon.Container, action string, username string, loginuid int64, success bool) {
-	switch action {
-	case "start":
-	case "stop":
-	case "create":
-	case "remove":
-		virt := audit.AuditVirtControl
-		vm := "?"
-		vmPid := "?"
-		exe := "?"
-		hostname := "?"
-		user := "?"
-		auid := "?"
+	virt := audit.AuditVirtControl
+	vm := "?"
+	vmPid := "?"
+	exe := "?"
+	hostname := "?"
+	user := "?"
+	auid := "?"
 
-		if c != nil {
-			vm = c.Config.Image
-			vmPid = fmt.Sprint(c.State.Pid)
-			exe = c.Path
-			hostname = c.Config.Hostname
-		}
-
-		if username != "" {
-			user = username
-		}
-
-		if loginuid != -1 {
-			auid = fmt.Sprint(loginuid)
-		}
-
-		vars := map[string]string{
-			"op":       action,
-			"reason":   "api",
-			"vm":       vm,
-			"vm-pid":   vmPid,
-			"user":     user,
-			"auid":     auid,
-			"exe":      exe,
-			"hostname": hostname,
-		}
-
-		//Encoding is a function of libaudit that ensures
-		//that the audit values contain only approved characters.
-		for key, value := range vars {
-			if audit.ValueNeedsEncoding(value) {
-				vars[key] = audit.EncodeNVString(key, value)
-			}
-		}
-		message := audit.FormatVars(vars)
-		audit.LogUserEvent(virt, message, success)
+	if c != nil {
+		vm = c.Config.Image
+		vmPid = fmt.Sprint(c.State.Pid)
+		exe = c.Path
+		hostname = c.Config.Hostname
 	}
+
+	if username != "" {
+		user = username
+	}
+
+	if loginuid != -1 {
+		auid = fmt.Sprint(loginuid)
+	}
+
+	vars := map[string]string{
+		"op":       action,
+		"reason":   "api",
+		"vm":       vm,
+		"vm-pid":   vmPid,
+		"user":     user,
+		"auid":     auid,
+		"exe":      exe,
+		"hostname": hostname,
+	}
+
+	//Encoding is a function of libaudit that ensures
+	//that the audit values contain only approved characters.
+	for key, value := range vars {
+		if audit.ValueNeedsEncoding(value) {
+			vars[key] = audit.EncodeNVString(key, value)
+		}
+	}
+	message := audit.FormatVars(vars)
+	audit.LogUserEvent(virt, message, success)
 }

--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -236,7 +236,6 @@ func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
 	switch action {
 	case "history", "info", "images", "version", "json", "search", "stats", "events":
 		logrus.Debug(message)
-		fallthrough
 	default:
 		logrus.Info(message)
 		logAuditlog(c, action, username, loginuid, true)


### PR DESCRIPTION
Fix BZ https://bugzilla.redhat.com/show_bug.cgi?id=1332016

I suspect the `logrus.Debug()` in `LogAction` call should be fixed into 1.10.3 and newer (1.11, 1.12) as well cause that isn't falling through but just logging *history* events ...ping @nalind

the switch from `logAuditlog` has been removed to be the same login as into 1.10.3 and newer..

The main problem was that *switch* in golang isn't working as in C and the fallthough logic is confusing though.. see comment below

ping @rhatdan 