### PR TITLE
Multiple fixes for SELinux labels.

### DIFF
--- a/container/container_unix.go
+++ b/container/container_unix.go
@@ -449,7 +449,9 @@ func (container *Container) NetworkMounts() []execdriver.Mount {
 		if _, err := os.Stat(container.ResolvConfPath); err != nil {
 			logrus.Warnf("ResolvConfPath set to %q, but can't stat this filename (err = %v); skipping", container.ResolvConfPath, err)
 		} else {
-			label.Relabel(container.ResolvConfPath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/resolv.conf") {
+				label.Relabel(container.ResolvConfPath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/resolv.conf"]; exists {
 				writable = m.RW
@@ -466,7 +468,9 @@ func (container *Container) NetworkMounts() []execdriver.Mount {
 		if _, err := os.Stat(container.HostnamePath); err != nil {
 			logrus.Warnf("HostnamePath set to %q, but can't stat this filename (err = %v); skipping", container.HostnamePath, err)
 		} else {
-			label.Relabel(container.HostnamePath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/hostname") {
+				label.Relabel(container.HostnamePath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/hostname"]; exists {
 				writable = m.RW
@@ -483,7 +487,9 @@ func (container *Container) NetworkMounts() []execdriver.Mount {
 		if _, err := os.Stat(container.HostsPath); err != nil {
 			logrus.Warnf("HostsPath set to %q, but can't stat this filename (err = %v); skipping", container.HostsPath, err)
 		} else {
-			label.Relabel(container.HostsPath, container.MountLabel, shared)
+			if !container.HasMountFor("/etc/hosts") {
+				label.Relabel(container.HostsPath, container.MountLabel, shared)
+			}
 			writable := !container.HostConfig.ReadonlyRootfs
 			if m, exists := container.MountPoints["/etc/hosts"]; exists {
 				writable = m.RW

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -131,8 +131,8 @@ func (daemon *Daemon) create(params types.ContainerCreateConfig) (retC *containe
 	return container, nil
 }
 
-func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMode containertypes.PidMode) ([]string, error) {
-	if ipcMode.IsHost() || pidMode.IsHost() {
+func (daemon *Daemon) generateSecurityOpt(ipcMode containertypes.IpcMode, pidMode containertypes.PidMode, privileged bool) ([]string, error) {
+	if ipcMode.IsHost() || pidMode.IsHost() || privileged {
 		return label.DisableSecOpt(), nil
 	}
 	if ipcContainer := ipcMode.Container(); ipcContainer != "" {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -204,7 +204,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *containertypes.HostConf
 	}
 	var err error
 	if hostConfig.SecurityOpt == nil {
-		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
+		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode, hostConfig.Privileged)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


SELinux labeling should be disabled when using --privileged mode

/etc/hosts, /etc/resolv.conf, /etc/hostname should not be relabeled if they
are volume mounted into the container.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>