### PR TITLE
BACKPORT: Do not use stream encoders

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/container_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/container_linux.go
@@ -18,6 +18,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/criurpc"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 const stdioFdCount = 3
@@ -863,7 +864,7 @@ func (c *linuxContainer) updateState(process parentProcess) error {
 	}
 	defer f.Close()
 	os.Remove(filepath.Join(c.root, "checkpoint"))
-	return json.NewEncoder(f).Encode(state)
+	return utils.WriteJSON(f, state)
 }
 
 func (c *linuxContainer) currentStatus() (Status, error) {

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/factory_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/factory_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/systemd"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/configs/validate"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 const (
@@ -228,7 +229,7 @@ func (l *LinuxFactory) StartInitialization() (err error) {
 			// ensure that any data sent from the parent is consumed so it doesn't
 			// receive ECONNRESET when the child writes to the pipe.
 			ioutil.ReadAll(pipe)
-			if err := json.NewEncoder(pipe).Encode(newSystemError(err)); err != nil {
+			if err := utils.WriteJSON(pipe, newSystemError(err)); err != nil {
 				panic(err)
 			}
 		}

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/process_linux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/runc/libcontainer/utils"
 )
 
 type parentProcess interface {
@@ -71,7 +72,7 @@ func (p *setnsProcess) start() (err error) {
 			return newSystemError(err)
 		}
 	}
-	if err := json.NewEncoder(p.parentPipe).Encode(p.config); err != nil {
+	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return newSystemError(err)
 	}
 	if err := syscall.Shutdown(int(p.parentPipe.Fd()), syscall.SHUT_WR); err != nil {
@@ -262,7 +263,7 @@ func (p *initProcess) startTime() (string, error) {
 
 func (p *initProcess) sendConfig() error {
 	// send the state to the container's init process then shutdown writes for the parent
-	if err := json.NewEncoder(p.parentPipe).Encode(p.config); err != nil {
+	if err := utils.WriteJSON(p.parentPipe, p.config); err != nil {
 		return err
 	}
 	// shutdown writes for the parent side of the pipe

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/utils/utils.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"path/filepath"
 	"syscall"
@@ -36,10 +37,20 @@ func ResolveRootfs(uncleanRootfs string) (string, error) {
 }
 
 // ExitStatus returns the correct exit status for a process based on if it
-// was signaled or existed cleanly.
+// was signaled or exited cleanly
 func ExitStatus(status syscall.WaitStatus) int {
 	if status.Signaled() {
 		return exitSignalOffset + int(status.Signal())
 	}
 	return status.ExitStatus()
+}
+
+// WriteJSON writes the provided struct v to w using standard json marshaling
+func WriteJSON(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
 }


### PR DESCRIPTION
Don't use json Encoder as it adds a new line causing sync issues between parent and child process in container setup. 
