### PR TITLE
Backport privileged containers with user namespaces patch

### DIFF
--- a/daemon/container_operations_unix.go
+++ b/daemon/container_operations_unix.go
@@ -222,11 +222,14 @@ func (daemon *Daemon) populateCommand(c *container.Container, env []string) erro
 	processConfig.Env = env
 
 	remappedRoot := &execdriver.User{}
-	rootUID, rootGID := daemon.GetRemappedUIDGID()
-	if rootUID != 0 {
-		remappedRoot.UID = rootUID
-		remappedRoot.GID = rootGID
+	if c.HostConfig.UsernsMode.IsPrivate() {
+		rootUID, rootGID := daemon.GetRemappedUIDGID()
+		if rootUID != 0 {
+			remappedRoot.UID = rootUID
+			remappedRoot.GID = rootGID
+		}
 	}
+
 	uidMap, gidMap := daemon.GetUIDGIDMaps()
 
 	if !daemon.seccompEnabled {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -411,7 +411,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
 	}
 	// check for various conflicting options with user namespaces
-	if daemon.configStore.RemappedRoot != "" {
+	if daemon.configStore.RemappedRoot != "" && hostConfig.UsernsMode.IsPrivate() {
 		if hostConfig.Privileged {
 			return warnings, fmt.Errorf("Privileged mode is incompatible with user namespaces.")
 		}

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -83,6 +83,9 @@ Creates a new container.
       --sysctl[=*[]*]]              Configure namespaced kernel parameters at runtime
       -t, --tty                     Allocate a pseudo-TTY
       -u, --user=""                 Username or UID
+      --userns=""                   Container user namespace
+                                    'host': Use the Docker host user namespace
+                                    '': Use the Docker daemon user namespace specified by `--userns-remap` option.
       --ulimit=[]                   Ulimit options
       --uts=""                      UTS namespace to use
       -v, --volume=[host-src:]container-dest[:<options>]

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -774,6 +774,16 @@ following algorithm to create the mapping ranges:
 2. Map segments will be created from each range in increasing value with a length matching the length of each segment. Therefore the range segment with the lowest numeric starting value will be equal to the remapped root, and continue up through host uid/gid equal to the range segment length. As an example, if the lowest segment starts at ID 1000 and has a length of 100, then a map of 1000 -> 0 (the remapped root) up through 1100 -> 100 will be created from this segment. If the next segment starts at ID 10000, then the next map will start with mapping 10000 -> 101 up to the length of this second segment. This will continue until no more segments are found in the subordinate files for this user.
 3. If more than five range segments exist for a single user, only the first five will be utilized, matching the kernel's limitation of only five entries in `/proc/self/uid_map` and `proc/self/gid_map`.
 
+### Disable user namespace for a container
+
+If you enable user namespaces on the daemon, all containers are started
+with user namespaces enabled. In some situations you might want to disable
+this feature for a container, for example, to start a privileged container (see
+[user namespace known restrictions](#user-namespace-known-restrictions)).
+To enable those advanced features for a specific container use `--userns=host`
+in the `run/exec/create` command.
+This option will completely disable user namespace mapping for the container's user.
+
 ### User namespace known restrictions
 
 The following standard Docker features are currently incompatible when

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -85,6 +85,9 @@ parent = "smn_cli"
       --sysctl[=*[]*]]              Configure namespaced kernel parameters at runtime
       -t, --tty                     Allocate a pseudo-TTY
       -u, --user=""                 Username or UID (format: <name|uid>[:<group|gid>])
+      --userns=""                   Container user namespace
+                                    'host': Use the Docker host user namespace
+                                    '': Use the Docker daemon user namespace specified by `--userns-remap` option.
       --ulimit=[]                   Ulimit options
       --uts=""                      UTS namespace to use
       -v, --volume=[host-src:]container-dest[:<options>]

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -21,8 +21,8 @@ clone git github.com/tchap/go-patricia v2.1.0
 clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
-clone git github.com/docker/go-connections v0.1.2
-clone git github.com/docker/engine-api v0.2.3
+clone git github.com/docker/go-connections v0.2.0
+clone git github.com/docker/engine-api 7108f731dd4aeede9a259d0b1a86f0b7d94f12c2
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -22,7 +22,7 @@ clone git github.com/vdemeester/shakers 3c10293ce22b900c27acad7b28656196fcc2f73b
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api 7108f731dd4aeede9a259d0b1a86f0b7d94f12c2
+clone git github.com/docker/engine-api 7f6071353fc48f69d2328c4ebe8f3bd0f7c75da4
 clone git github.com/RackSec/srslog 6eb773f331e46fbba8eecb8e794e635e75fc04de
 clone git github.com/imdario/mergo 0.2.1
 

--- a/integration-cli/docker_cli_experimental_test.go
+++ b/integration-cli/docker_cli_experimental_test.go
@@ -3,17 +3,9 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strconv"
-	"strings"
-
 	"github.com/docker/docker/pkg/integration/checker"
-	"github.com/docker/docker/pkg/system"
 	"github.com/go-check/check"
+	"strings"
 )
 
 func (s *DockerSuite) TestExperimentalVersion(c *check.C) {
@@ -26,51 +18,4 @@ func (s *DockerSuite) TestExperimentalVersion(c *check.C) {
 
 	out, _ = dockerCmd(c, "-v")
 	c.Assert(out, checker.Contains, ", experimental", check.Commentf("docker version did not contain experimental"))
-}
-
-// user namespaces test: run daemon with remapped root setting
-// 1. validate uid/gid maps are set properly
-// 2. verify that files created are owned by remapped root
-func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
-	testRequires(c, DaemonIsLinux, SameHostDaemon)
-
-	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
-
-	tmpDir, err := ioutil.TempDir("", "userns")
-	c.Assert(err, checker.IsNil)
-	defer os.RemoveAll(tmpDir)
-
-	// we need to find the uid and gid of the remapped root from the daemon's root dir info
-	uidgid := strings.Split(filepath.Base(s.d.root), ".")
-	c.Assert(uidgid, checker.HasLen, 2, check.Commentf("Should have gotten uid/gid strings from root dirname: %s", filepath.Base(s.d.root)))
-	uid, err := strconv.Atoi(uidgid[0])
-	c.Assert(err, checker.IsNil, check.Commentf("Can't parse uid"))
-	gid, err := strconv.Atoi(uidgid[1])
-	c.Assert(err, checker.IsNil, check.Commentf("Can't parse gid"))
-
-	//writeable by the remapped root UID/GID pair
-	c.Assert(os.Chown(tmpDir, uid, gid), checker.IsNil)
-
-	out, err := s.d.Cmd("run", "-d", "--name", "userns", "-v", tmpDir+":/goofy", "busybox", "sh", "-c", "touch /goofy/testfile; top")
-	c.Assert(err, checker.IsNil, check.Commentf("Output: %s", out))
-
-	pid, err := s.d.Cmd("inspect", "--format='{{.State.Pid}}'", "userns")
-	c.Assert(err, checker.IsNil, check.Commentf("Could not inspect running container: out: %q", pid))
-	// check the uid and gid maps for the PID to ensure root is remapped
-	// (cmd = cat /proc/<pid>/uid_map | grep -E '0\s+9999\s+1')
-	out, rc1, err := runCommandPipelineWithOutput(
-		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/uid_map"),
-		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", uid)))
-	c.Assert(rc1, checker.Equals, 0, check.Commentf("Didn't match uid_map: output: %s", out))
-
-	out, rc2, err := runCommandPipelineWithOutput(
-		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/gid_map"),
-		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", gid)))
-	c.Assert(rc2, checker.Equals, 0, check.Commentf("Didn't match gid_map: output: %s", out))
-
-	// check that the touched file is owned by remapped uid:gid
-	stat, err := system.Stat(filepath.Join(tmpDir, "testfile"))
-	c.Assert(err, checker.IsNil)
-	c.Assert(stat.UID(), checker.Equals, uint32(uid), check.Commentf("Touched file not owned by remapped root UID"))
-	c.Assert(stat.GID(), checker.Equals, uint32(gid), check.Commentf("Touched file not owned by remapped root GID"))
 }

--- a/integration-cli/docker_cli_userns_test.go
+++ b/integration-cli/docker_cli_userns_test.go
@@ -1,0 +1,65 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/pkg/integration/checker"
+	"github.com/docker/docker/pkg/system"
+	"github.com/go-check/check"
+)
+
+// user namespaces test: run daemon with remapped root setting
+// 1. validate uid/gid maps are set properly
+// 2. verify that files created are owned by remapped root
+func (s *DockerDaemonSuite) TestDaemonUserNamespaceRootSetting(c *check.C) {
+	testRequires(c, DaemonIsLinux, SameHostDaemon)
+
+	c.Assert(s.d.StartWithBusybox("--userns-remap", "default"), checker.IsNil)
+
+	tmpDir, err := ioutil.TempDir("", "userns")
+	c.Assert(err, checker.IsNil)
+
+	defer os.RemoveAll(tmpDir)
+
+	// we need to find the uid and gid of the remapped root from the daemon's root dir info
+	uidgid := strings.Split(filepath.Base(s.d.root), ".")
+	c.Assert(uidgid, checker.HasLen, 2, check.Commentf("Should have gotten uid/gid strings from root dirname: %s", filepath.Base(s.d.root)))
+	uid, err := strconv.Atoi(uidgid[0])
+	c.Assert(err, checker.IsNil, check.Commentf("Can't parse uid"))
+	gid, err := strconv.Atoi(uidgid[1])
+	c.Assert(err, checker.IsNil, check.Commentf("Can't parse gid"))
+
+	//writeable by the remapped root UID/GID pair
+	c.Assert(os.Chown(tmpDir, uid, gid), checker.IsNil)
+
+	out, err := s.d.Cmd("run", "-d", "--name", "userns", "-v", tmpDir+":/goofy", "busybox", "sh", "-c", "touch /goofy/testfile; top")
+	c.Assert(err, checker.IsNil, check.Commentf("Output: %s", out))
+
+	pid, err := s.d.Cmd("inspect", "--format='{{.State.Pid}}'", "userns")
+	c.Assert(err, checker.IsNil, check.Commentf("Could not inspect running container: out: %q", pid))
+	// check the uid and gid maps for the PID to ensure root is remapped
+	// (cmd = cat /proc/<pid>/uid_map | grep -E '0\s+9999\s+1')
+	out, rc1, err := runCommandPipelineWithOutput(
+		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/uid_map"),
+		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", uid)))
+	c.Assert(rc1, checker.Equals, 0, check.Commentf("Didn't match uid_map: output: %s", out))
+
+	out, rc2, err := runCommandPipelineWithOutput(
+		exec.Command("cat", "/proc/"+strings.TrimSpace(pid)+"/gid_map"),
+		exec.Command("grep", "-E", fmt.Sprintf("0[[:space:]]+%d[[:space:]]+", gid)))
+	c.Assert(rc2, checker.Equals, 0, check.Commentf("Didn't match gid_map: output: %s", out))
+
+	// check that the touched file is owned by remapped uid:gid
+	stat, err := system.Stat(filepath.Join(tmpDir, "testfile"))
+	c.Assert(err, checker.IsNil)
+	c.Assert(stat.UID(), checker.Equals, uint32(uid), check.Commentf("Touched file not owned by remapped root UID"))
+	c.Assert(stat.GID(), checker.Equals, uint32(gid), check.Commentf("Touched file not owned by remapped root GID"))
+}

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -58,6 +58,7 @@ docker-create - Create a new container
 [**-P**|**--publish-all**]
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
+[**--userns**[=*[]*]]
 [**--privileged**]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
@@ -290,6 +291,10 @@ unit, `b` is used. Set LIMIT to `-1` to enable unlimited swap.
    Set the PID mode for the container
      **host**: use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
+
+**--userns**=""
+   Set the usernamespace mode for the container when `userns-remap` option is enabled.
+     **host**: use the host usernamespace and enable all privileged options (e.g., `pid=host` or `--privileged`).
 
 **--privileged**=*true*|*false*
    Give extended privileges to this container. The default is *false*.

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -60,6 +60,7 @@ docker-run - Run a command in a new container
 [**-P**|**--publish-all**]
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
+[**--userns**[=*[]*]]
 [**--privileged**]
 [**--read-only**]
 [**--restart**[=*RESTART*]]
@@ -420,6 +421,10 @@ Use `docker port` to see the actual mapping: `docker port CONTAINER $CONTAINERPO
    Set the PID mode for the container
      **host**: use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
+
+**--userns**=""
+   Set the usernamespace mode for the container when `userns-remap` option is enabled.
+     **host**: use the host usernamespace and enable all privileged options (e.g., `pid=host` or `--privileged`).
 
 **--uts**=*host*
    Set the UTS mode for the container

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -121,6 +121,27 @@ func TestUTSModeTest(t *testing.T) {
 	}
 }
 
+func TestUsernsModeTest(t *testing.T) {
+	usrensMode := map[container.UsernsMode][]bool{
+		// private, host, valid
+		"":                {true, false, true},
+		"something:weird": {true, false, false},
+		"host":            {false, true, true},
+		"host:name":       {true, false, true},
+	}
+	for usernsMode, state := range usrensMode {
+		if usernsMode.IsPrivate() != state[0] {
+			t.Fatalf("UsernsMode.IsPrivate for %v should have been %v but was %v", usernsMode, state[0], usernsMode.IsPrivate())
+		}
+		if usernsMode.IsHost() != state[1] {
+			t.Fatalf("UsernsMode.IsHost for %v should have been %v but was %v", usernsMode, state[1], usernsMode.IsHost())
+		}
+		if usernsMode.Valid() != state[2] {
+			t.Fatalf("UsernsMode.Valid for %v should have been %v but was %v", usernsMode, state[2], usernsMode.Valid())
+		}
+	}
+}
+
 func TestPidModeTest(t *testing.T) {
 	pidModes := map[container.PidMode][]bool{
 		// private, host, valid

--- a/runconfig/opts/parse.go
+++ b/runconfig/opts/parse.go
@@ -60,6 +60,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		flPrivileged        = cmd.Bool([]string{"-privileged"}, false, "Give extended privileges to this container")
 		flPidMode           = cmd.String([]string{"-pid"}, "", "PID namespace to use")
 		flUTSMode           = cmd.String([]string{"-uts"}, "", "UTS namespace to use")
+		flUsernsMode        = cmd.String([]string{"-userns"}, "", "User namespace to use")
 		flPublishAll        = cmd.Bool([]string{"P", "-publish-all"}, false, "Publish all exposed ports to random ports")
 		flStdin             = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty               = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
@@ -317,6 +318,11 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		return nil, nil, nil, cmd, fmt.Errorf("--uts: invalid UTS mode")
 	}
 
+	usernsMode := container.UsernsMode(*flUsernsMode)
+	if !usernsMode.Valid() {
+		return nil, nil, nil, cmd, fmt.Errorf("--userns: invalid USER mode")
+	}
+
 	restartPolicy, err := ParseRestartPolicy(*flRestartPolicy)
 	if err != nil {
 		return nil, nil, nil, cmd, err
@@ -405,6 +411,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*container.Config, *container.Host
 		IpcMode:        ipcMode,
 		PidMode:        pidMode,
 		UTSMode:        utsMode,
+		UsernsMode:     usernsMode,
 		CapAdd:         strslice.New(flCapAdd.GetAll()...),
 		CapDrop:        strslice.New(flCapDrop.GetAll()...),
 		GroupAdd:       flGroupAdd.GetAll(),

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -200,7 +200,6 @@ type Resources struct {
 	CpusetCpus           string          // CpusetCpus 0-2, 0,1
 	CpusetMems           string          // CpusetMems 0-2, 0,1
 	Devices              []DeviceMapping // List of devices to map inside the container
-	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
@@ -208,11 +207,6 @@ type Resources struct {
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
-
-	// Applicable to Windows
-	BlkioIOps   uint64 // Maximum IOps for the container system drive
-	BlkioBps    uint64 // Maximum Bytes per second for the container system drive
-	SandboxSize uint64 // System drive will be expanded to at least this size (in bytes)
 }
 
 // UpdateConfig holds the mutable attributes of a Container.
@@ -254,7 +248,7 @@ type HostConfig struct {
 	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
 	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode            // UTS namespace to use for the container
-	UsernsMode      UsernsMode        // The user namespace to use for the container
+	UsernsMode      UsernsMode         `json:",omitempty"` // The user namespace to use for the container
 	ShmSize         int64              // Total shm memory usage
 	Sysctls         map[string]string  `json:",omitempty"` // List of Namespaced sysctls used for the container
 	// Applicable to Windows

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -199,6 +199,7 @@ type Resources struct {
 	CpusetCpus           string          // CpusetCpus 0-2, 0,1
 	CpusetMems           string          // CpusetMems 0-2, 0,1
 	Devices              []DeviceMapping // List of devices to map inside the container
+	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
 	Memory               int64           // Memory limit (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -65,6 +65,30 @@ func (n IpcMode) Container() string {
 	return ""
 }
 
+// UsernsMode represents userns mode in the container.
+type UsernsMode string
+
+// IsHost indicates whether the container uses the host's userns.
+func (n UsernsMode) IsHost() bool {
+	return n == "host"
+}
+
+// IsPrivate indicates whether the container uses the a private userns.
+func (n UsernsMode) IsPrivate() bool {
+	return !(n.IsHost())
+}
+
+// Valid indicates whether the userns is valid.
+func (n UsernsMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	default:
+		return false
+	}
+	return true
+}
+
 // UTSMode represents the UTS namespace of the container.
 type UTSMode string
 

--- a/vendor/src/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/host_config.go
@@ -185,6 +185,7 @@ type LogConfig struct {
 type Resources struct {
 	// Applicable to all platforms
 	CPUShares int64 `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+	Memory    int64 // Memory limit (in bytes)
 
 	// Applicable to UNIX platforms
 	CgroupParent         string // Parent cgroup.
@@ -201,13 +202,17 @@ type Resources struct {
 	Devices              []DeviceMapping // List of devices to map inside the container
 	DiskQuota            int64           // Disk limit (in bytes)
 	KernelMemory         int64           // Kernel memory limit (in bytes)
-	Memory               int64           // Memory limit (in bytes)
 	MemoryReservation    int64           // Memory soft limit (in bytes)
 	MemorySwap           int64           // Total memory usage (memory + swap); set `-1` to disable swap
 	MemorySwappiness     *int64          // Tuning container memory swappiness behaviour
 	OomKillDisable       *bool           // Whether to disable OOM Killer or not
 	PidsLimit            int64           // Setting pids limit for a container
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
+
+	// Applicable to Windows
+	BlkioIOps   uint64 // Maximum IOps for the container system drive
+	BlkioBps    uint64 // Maximum Bytes per second for the container system drive
+	SandboxSize uint64 // System drive will be expanded to at least this size (in bytes)
 }
 
 // UpdateConfig holds the mutable attributes of a Container.
@@ -249,6 +254,7 @@ type HostConfig struct {
 	SecurityOpt     []string           // List of string values to customize labels for MLS systems, such as SELinux.
 	Tmpfs           map[string]string  `json:",omitempty"` // List of tmpfs (mounts) used for the container
 	UTSMode         UTSMode            // UTS namespace to use for the container
+	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64              // Total shm memory usage
 	Sysctls         map[string]string  `json:",omitempty"` // List of Namespaced sysctls used for the container
 	// Applicable to Windows

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -209,7 +209,6 @@ type Info struct {
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
-	KernelMemory       bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool

--- a/vendor/src/github.com/docker/engine-api/types/types.go
+++ b/vendor/src/github.com/docker/engine-api/types/types.go
@@ -209,6 +209,7 @@ type Info struct {
 	Plugins            PluginsInfo
 	MemoryLimit        bool
 	SwapLimit          bool
+	KernelMemory       bool
 	CPUCfsPeriod       bool `json:"CpuCfsPeriod"`
 	CPUCfsQuota        bool `json:"CpuCfsQuota"`
 	CPUShares          bool


### PR DESCRIPTION
This enables user namespaces to be used with privileged containers and --net=host or --pid=host. Important patch to make user namespaces usable in cluster orchestration and similar scenarios.

This introduces a non-breaking API change (adds a field to hostconfig). I've tested locally to try and make sure it's non-breaking, but further testing is definitely necessary to make sure this doesn't blow anything up.