### PR TITLE
Overlay now supports SELinux

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -616,13 +616,7 @@ func configureMaxThreads(config *Config) error {
 // configureKernelSecuritySupport configures and validates security support for the kernel
 func configureKernelSecuritySupport(config *Config, driverName string) error {
 	if config.EnableSelinuxSupport {
-		if selinuxEnabled() {
-			// As Docker on overlayFS and SELinux are incompatible at present, error on overlayfs being enabled
-			if driverName == "overlay" {
-				return fmt.Errorf("SELinux is not supported with the %s graph driver", driverName)
-			}
-			logrus.Debug("SELinux enabled successfully")
-		} else {
+		if !selinuxEnabled() {
 			logrus.Warn("Docker could not enable SELinux on the host system")
 		}
 	} else {

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -243,7 +243,7 @@ output otherwise.
   Force the Docker runtime to use a specific storage driver.
 
 **--selinux-enabled**=*true*|*false*
-  Enable selinux support. Default is false. SELinux does not presently support either of the overlay storage drivers.
+  Enable selinux support. Default is false.
 
 **--storage-opt**=[]
   Set storage driver options. See STORAGE DRIVER OPTIONS.


### PR DESCRIPTION
Remove calls that block selinux-enabeled on overlayfs file systems