### PR TITLE
BACKPORT: fix init.scope in cgroup paths

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/cgroups/systemd/apply_systemd.go
@@ -330,6 +330,9 @@ func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
 		return "", err
 	}
 
+	// if pid 1 is systemd 226 or later, it will be in init.scope, not the root
+	initPath = strings.TrimSuffix(filepath.Clean(initPath), "init.scope")
+
 	slice := "system.slice"
 	if c.Parent != "" {
 		slice = c.Parent


### PR DESCRIPTION
This removes init.scope from cgroup paths for the container.

See https://github.com/opencontainers/runc/commit/4b44b98596dba2e4c529ddfbd702de1e4e8149ec

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>