### PR TITLE
Stat blob in target repository before a push

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -422,17 +422,13 @@ func (pd *v2PushDescriptor) Descriptor() distribution.Descriptor {
 // knows about, it returns the known digest and "true".
 func layerAlreadyExists(ctx context.Context, metadata []metadata.V2Metadata, repoInfo reference.Named, repo distribution.Repository, pushState *pushState) (distribution.Descriptor, bool, error) {
 	for _, meta := range metadata {
-		// Only check blobsums that are known to this repository or have an unknown source
-		if meta.SourceRepository != "" && meta.SourceRepository != repoInfo.FullName() {
-			continue
-		}
 		descriptor, err := repo.Blobs(ctx).Stat(ctx, meta.Digest)
 		switch err {
 		case nil:
 			descriptor.MediaType = schema2.MediaTypeLayer
 			return descriptor, true, nil
 		case distribution.ErrBlobUnknown:
-			// nop
+			return distribution.Descriptor{}, false, nil
 		default:
 			return distribution.Descriptor{}, false, err
 		}


### PR DESCRIPTION
This partially addresses performance issue described at

   https://bugzilla.redhat.com/show_bug.cgi?id=1368024#c1

In short: if there are multiple users involved in pushing to multiple private repositories using the same docker daemon, cross-repo mount doesn't work and blobs get re-uploaded even if they exist in target
repository.