### PR TITLE
read from /etc/container/rhel/secrets also

### DIFF
--- a/container/secrets.go
+++ b/container/secrets.go
@@ -6,6 +6,11 @@ import (
 	"path/filepath"
 )
 
+const (
+	baseDir     = "/usr/share/rhel/secrets"
+	overrideDir = "/etc/container/rhel/secrets"
+)
+
 // Secret info
 type Secret struct {
 	Name      string
@@ -81,5 +86,8 @@ func readFile(root, name string) ([]SecretData, error) {
 }
 
 func getHostSecretData() ([]SecretData, error) {
-	return readAll("/usr/share/rhel/secrets", "")
+	if _, err := os.Stat(overrideDir); err == nil {
+		return readAll(overrideDir, "")
+	}
+	return readAll(baseDir, "")
 }


### PR DESCRIPTION
Fix https://github.com/projectatomic/docker/issues/186

@rhatdan @cgwalters @parthaa PTAL

- I'll take care of moving this patch once merged in 1.10.3 fedora and rhel
- I've also to modify `docker.spec` to include `/etc/container/rhel/secrets` in `%files` as we do for `/usr/share/rhel/secrets`