### PR TITLE
Backport always store image digest when pulling and pushing

### DIFF
--- a/api/client/formatter/formatter.go
+++ b/api/client/formatter/formatter.go
@@ -162,6 +162,10 @@ ports: {{.Ports}}
 	ctx.postformat(tmpl, &containerContext{})
 }
 
+func isDangling(image types.Image) bool {
+	return len(image.RepoTags) == 1 && image.RepoTags[0] == "<none>:<none>" && len(image.RepoDigests) == 1 && image.RepoDigests[0] == "<none>@<none>"
+}
+
 func (ctx ImageContext) Write() {
 	switch ctx.Format {
 	case tableFormatKey:
@@ -207,42 +211,98 @@ virtual_size: {{.Size}}
 	}
 
 	for _, image := range ctx.Images {
+		images := []*imageContext{}
+		if isDangling(image) {
+			images = append(images, &imageContext{
+				trunc:  ctx.Trunc,
+				i:      image,
+				repo:   "<none>",
+				tag:    "<none>",
+				digest: "<none>",
+			})
+		} else {
+			repoTags := map[string][]string{}
+			repoDigests := map[string][]string{}
 
-		repoTags := image.RepoTags
-		repoDigests := image.RepoDigests
-
-		if len(repoTags) == 1 && repoTags[0] == "<none>:<none>" && len(repoDigests) == 1 && repoDigests[0] == "<none>@<none>" {
-			// dangling image - clear out either repoTags or repoDigests so we only show it once below
-			repoDigests = []string{}
-		}
-		// combine the tags and digests lists
-		tagsAndDigests := append(repoTags, repoDigests...)
-		for _, repoAndRef := range tagsAndDigests {
-			repo := "<none>"
-			tag := "<none>"
-			digest := "<none>"
-
-			if !strings.HasPrefix(repoAndRef, "<none>") {
-				ref, err := reference.ParseNamed(repoAndRef)
+			for _, refString := range append(image.RepoTags) {
+				ref, err := reference.ParseNamed(refString)
 				if err != nil {
 					continue
 				}
-				repo = ref.Name()
-
-				switch x := ref.(type) {
-				case reference.Canonical:
-					digest = x.Digest().String()
-				case reference.NamedTagged:
-					tag = x.Tag()
+				if nt, ok := ref.(reference.NamedTagged); ok {
+					repoTags[ref.Name()] = append(repoTags[ref.Name()], nt.Tag())
 				}
 			}
-			imageCtx := &imageContext{
-				trunc:  ctx.Trunc,
-				i:      image,
-				repo:   repo,
-				tag:    tag,
-				digest: digest,
+			for _, refString := range append(image.RepoDigests) {
+				ref, err := reference.ParseNamed(refString)
+				if err != nil {
+					continue
+				}
+				if c, ok := ref.(reference.Canonical); ok {
+					repoDigests[ref.Name()] = append(repoDigests[ref.Name()], c.Digest().String())
+				}
 			}
+
+			for repo, tags := range repoTags {
+				digests := repoDigests[repo]
+
+				// Do not display digests as their own row
+				delete(repoDigests, repo)
+
+				if !ctx.Digest {
+					// Ignore digest references, just show tag once
+					digests = nil
+				}
+
+				for _, tag := range tags {
+					if len(digests) == 0 {
+						images = append(images, &imageContext{
+							trunc:  ctx.Trunc,
+							i:      image,
+							repo:   repo,
+							tag:    tag,
+							digest: "<none>",
+						})
+						continue
+					}
+					// Display the digests for each tag
+					for _, dgst := range digests {
+						images = append(images, &imageContext{
+							trunc:  ctx.Trunc,
+							i:      image,
+							repo:   repo,
+							tag:    tag,
+							digest: dgst,
+						})
+					}
+
+				}
+			}
+
+			// Show rows for remaining digest only references
+			for repo, digests := range repoDigests {
+				// If digests are displayed, show row per digest
+				if ctx.Digest {
+					for _, dgst := range digests {
+						images = append(images, &imageContext{
+							trunc:  ctx.Trunc,
+							i:      image,
+							repo:   repo,
+							tag:    "<none>",
+							digest: dgst,
+						})
+					}
+				} else {
+					images = append(images, &imageContext{
+						trunc: ctx.Trunc,
+						i:     image,
+						repo:  repo,
+						tag:   "<none>",
+					})
+				}
+			}
+		}
+		for _, imageCtx := range images {
 			err = ctx.contextFormat(tmpl, imageCtx)
 			if err != nil {
 				return

--- a/api/client/formatter/formatter_test.go
+++ b/api/client/formatter/formatter_test.go
@@ -282,7 +282,6 @@ func TestImageContextWrite(t *testing.T) {
 			},
 			`REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
 image               tag1                imageID1            24 hours ago        0 B
-image               <none>              imageID1            24 hours ago        0 B
 image               tag2                imageID2            24 hours ago        0 B
 <none>              <none>              imageID3            24 hours ago        0 B
 `,
@@ -293,7 +292,7 @@ image               tag2                imageID2            24 hours ago        
 					Format: "table {{.Repository}}",
 				},
 			},
-			"REPOSITORY\nimage\nimage\nimage\n<none>\n",
+			"REPOSITORY\nimage\nimage\n<none>\n",
 		},
 		{
 			ImageContext{
@@ -303,7 +302,6 @@ image               tag2                imageID2            24 hours ago        
 				Digest: true,
 			},
 			`REPOSITORY          DIGEST
-image               <none>
 image               sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
 image               <none>
 <none>              <none>
@@ -316,7 +314,7 @@ image               <none>
 					Quiet:  true,
 				},
 			},
-			"REPOSITORY\nimage\nimage\nimage\n<none>\n",
+			"REPOSITORY\nimage\nimage\n<none>\n",
 		},
 		{
 			ImageContext{
@@ -325,7 +323,7 @@ image               <none>
 					Quiet:  true,
 				},
 			},
-			"imageID1\nimageID1\nimageID2\nimageID3\n",
+			"imageID1\nimageID2\nimageID3\n",
 		},
 		{
 			ImageContext{
@@ -336,8 +334,7 @@ image               <none>
 				Digest: true,
 			},
 			`REPOSITORY          TAG                 DIGEST                                                                    IMAGE ID            CREATED             SIZE
-image               tag1                <none>                                                                    imageID1            24 hours ago        0 B
-image               <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   imageID1            24 hours ago        0 B
+image               tag1                sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   imageID1            24 hours ago        0 B
 image               tag2                <none>                                                                    imageID2            24 hours ago        0 B
 <none>              <none>              <none>                                                                    imageID3            24 hours ago        0 B
 `,
@@ -350,7 +347,7 @@ image               tag2                <none>                                  
 				},
 				Digest: true,
 			},
-			"imageID1\nimageID1\nimageID2\nimageID3\n",
+			"imageID1\nimageID2\nimageID3\n",
 		},
 		// Raw Format
 		{
@@ -361,12 +358,6 @@ image               tag2                <none>                                  
 			},
 			fmt.Sprintf(`repository: image
 tag: tag1
-image_id: imageID1
-created_at: %s
-virtual_size: 0 B
-
-repository: image
-tag: <none>
 image_id: imageID1
 created_at: %s
 virtual_size: 0 B
@@ -383,7 +374,7 @@ image_id: imageID3
 created_at: %s
 virtual_size: 0 B
 
-`, expectedTime, expectedTime, expectedTime, expectedTime),
+`, expectedTime, expectedTime, expectedTime),
 		},
 		{
 			ImageContext{
@@ -394,13 +385,6 @@ virtual_size: 0 B
 			},
 			fmt.Sprintf(`repository: image
 tag: tag1
-digest: <none>
-image_id: imageID1
-created_at: %s
-virtual_size: 0 B
-
-repository: image
-tag: <none>
 digest: sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
 image_id: imageID1
 created_at: %s
@@ -420,7 +404,7 @@ image_id: imageID3
 created_at: %s
 virtual_size: 0 B
 
-`, expectedTime, expectedTime, expectedTime, expectedTime),
+`, expectedTime, expectedTime, expectedTime),
 		},
 		{
 			ImageContext{
@@ -430,7 +414,6 @@ virtual_size: 0 B
 				},
 			},
 			`image_id: imageID1
-image_id: imageID1
 image_id: imageID2
 image_id: imageID3
 `,
@@ -442,7 +425,7 @@ image_id: imageID3
 					Format: "{{.Repository}}",
 				},
 			},
-			"image\nimage\nimage\n<none>\n",
+			"image\nimage\n<none>\n",
 		},
 		{
 			ImageContext{
@@ -451,7 +434,7 @@ image_id: imageID3
 				},
 				Digest: true,
 			},
-			"image\nimage\nimage\n<none>\n",
+			"image\nimage\n<none>\n",
 		},
 	}
 

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -118,7 +118,14 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 				// Remove canonical references from same repository
 				remainingRefs := []reference.Named{}
 				for _, repoRef := range repoRefs {
-					if _, repoRefIsCanonical := repoRef.(reference.Canonical); repoRefIsCanonical && parsedRef.Name() == repoRef.Name() {
+					r := parsedRef
+					if !reference.IsReferenceFullyQualified(r) {
+						r, err = reference.SubstituteReferenceName(r, repoRef.Name())
+						if err != nil {
+							return nil, err
+						}
+					}
+					if _, repoRefIsCanonical := repoRef.(reference.Canonical); repoRefIsCanonical && r.Name() == repoRef.Name() {
 						if _, err := daemon.removeImageRef(repoRef); err != nil {
 							return records, err
 						}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -76,7 +76,7 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		// first. We can only remove this reference if either force is
 		// true, there are multiple repository references to this
 		// image, or there are no containers using the given reference.
-		if !(force || len(repoRefs) > 1) {
+		if !force && isSingleReference(repoRefs) {
 			if container := daemon.getContainerUsingImage(imgID); container != nil {
 				// If we removed the repository reference then
 				// this image would remain "dangling" and since

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -103,27 +103,34 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 
 		repoRefs = daemon.referenceStore.References(imgID)
 
-		// If this is a tag reference and all the remaining references
-		// to this image are digest references, delete the remaining
-		// references so that they don't prevent removal of the image.
+		// If a tag reference was removed and the only remaining
+		// references to the same repository are digest references,
+		// then clean up those digest references.
 		if _, isCanonical := parsedRef.(reference.Canonical); !isCanonical {
-			foundTagRef := false
+			foundRepoTagRef := false
 			for _, repoRef := range repoRefs {
-				if _, repoRefIsCanonical := repoRef.(reference.Canonical); !repoRefIsCanonical {
-					foundTagRef = true
+				if _, repoRefIsCanonical := repoRef.(reference.Canonical); !repoRefIsCanonical && parsedRef.Name() == repoRef.Name() {
+					foundRepoTagRef = true
 					break
 				}
 			}
-			if !foundTagRef {
+			if !foundRepoTagRef {
+				// Remove canonical references from same repository
+				remainingRefs := []reference.Named{}
 				for _, repoRef := range repoRefs {
-					if _, err := daemon.removeImageRef(repoRef); err != nil {
-						return records, err
-					}
+					if _, repoRefIsCanonical := repoRef.(reference.Canonical); repoRefIsCanonical && parsedRef.Name() == repoRef.Name() {
+						if _, err := daemon.removeImageRef(repoRef); err != nil {
+							return records, err
+						}
 
-					untaggedRecord := types.ImageDelete{Untagged: repoRef.String()}
-					records = append(records, untaggedRecord)
+						untaggedRecord := types.ImageDelete{Untagged: repoRef.String()}
+						records = append(records, untaggedRecord)
+					} else {
+						remainingRefs = append(remainingRefs, repoRef)
+
+					}
 				}
-				repoRefs = []reference.Named{}
+				repoRefs = remainingRefs
 			}
 		}
 
@@ -134,11 +141,10 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 
 		removedRepositoryRef = true
 	} else {
-		// If an ID reference was given AND there is exactly one
-		// repository reference to the image then we will want to
-		// remove that reference.
-		// FIXME: Is this the behavior we want?
-		if len(repoRefs) == 1 {
+		// If an ID reference was given AND there is at most one tag
+		// reference to the image AND all references are within one
+		// repository, then remove all references.
+		if isSingleReference(repoRefs) {
 			c := conflictHard
 			if !force {
 				c |= conflictSoft &^ conflictActiveReference
@@ -147,19 +153,46 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 				return nil, conflict
 			}
 
-			parsedRef, err := daemon.removeImageRef(repoRefs[0])
-			if err != nil {
-				return nil, err
+			for _, repoRef := range repoRefs {
+				parsedRef, err := daemon.removeImageRef(repoRef)
+				if err != nil {
+					return nil, err
+				}
+
+				untaggedRecord := types.ImageDelete{Untagged: parsedRef.String()}
+
+				daemon.LogImageEvent(imgID.String(), imgID.String(), "untag")
+				records = append(records, untaggedRecord)
 			}
-
-			untaggedRecord := types.ImageDelete{Untagged: parsedRef.String()}
-
-			daemon.LogImageEvent(imgID.String(), imgID.String(), "untag")
-			records = append(records, untaggedRecord)
 		}
 	}
 
 	return records, daemon.imageDeleteHelper(imgID, &records, force, prune, removedRepositoryRef)
+}
+
+// isSingleReference returns true when all references are from one repository
+// and there is at most one tag. Returns false for empty input.
+func isSingleReference(repoRefs []reference.Named) bool {
+	if len(repoRefs) <= 1 {
+		return len(repoRefs) == 1
+	}
+	var singleRef reference.Named
+	canonicalRefs := map[string]struct{}{}
+	for _, repoRef := range repoRefs {
+		if _, isCanonical := repoRef.(reference.Canonical); isCanonical {
+			canonicalRefs[repoRef.Name()] = struct{}{}
+		} else if singleRef == nil {
+			singleRef = repoRef
+		} else {
+			return false
+		}
+	}
+	if singleRef == nil {
+		// Just use first canonical ref
+		singleRef = repoRefs[0]
+	}
+	_, ok := canonicalRefs[singleRef.Name()]
+	return len(canonicalRefs) == 1 && ok
 }
 
 // isImageIDPrefix returns whether the given possiblePrefix is a prefix of the

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -169,7 +169,7 @@ func (daemon *Daemon) Images(filterArgs, filter string, all bool) ([]*types.Imag
 			} else {
 				continue
 			}
-		} else if danglingOnly {
+		} else if danglingOnly && len(newImage.RepoTags) > 0 {
 			continue
 		}
 

--- a/distribution/pull.go
+++ b/distribution/pull.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/distribution/metadata"
 	"github.com/docker/docker/distribution/xfer"
@@ -244,4 +245,23 @@ func tmpFileCloser(tmpFile *os.File) func() error {
 
 		return nil
 	}
+}
+
+func addDigestReference(store reference.Store, ref reference.Named, dgst digest.Digest, imageID image.ID) error {
+	dgstRef, err := reference.WithDigest(ref, dgst)
+	if err != nil {
+		return err
+	}
+
+	if oldTagImageID, err := store.Get(dgstRef); err == nil {
+		if oldTagImageID != imageID {
+			// Updating digests not supported by reference store
+			logrus.Errorf("Image ID for digest %s changed from %s to %s, cannot update", dgst.String(), oldTagImageID, imageID)
+		}
+		return nil
+	} else if err != reference.ErrDoesNotExist {
+		return err
+	}
+
+	return store.AddDigest(dgstRef, imageID, true)
 }

--- a/distribution/pull_v2.go
+++ b/distribution/pull_v2.go
@@ -287,7 +287,7 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 	oldTagImageID, err := p.config.ReferenceStore.Get(ref)
 	if err == nil {
 		if oldTagImageID == imageID {
-			return false, nil
+			return false, addDigestReference(p.config.ReferenceStore, ref, manifestDigest, imageID)
 		}
 	} else if err != reference.ErrDoesNotExist {
 		return false, err
@@ -297,10 +297,14 @@ func (p *v2Puller) pullV2Tag(ctx context.Context, ref reference.Named) (tagUpdat
 		if err = p.config.ReferenceStore.AddDigest(canonical, imageID, true); err != nil {
 			return false, err
 		}
-	} else if err = p.config.ReferenceStore.AddTag(ref, imageID, true); err != nil {
-		return false, err
+	} else {
+		if err = addDigestReference(p.config.ReferenceStore, ref, manifestDigest, imageID); err != nil {
+			return false, err
+		}
+		if err = p.config.ReferenceStore.AddTag(ref, imageID, true); err != nil {
+			return false, err
+		}
 	}
-
 	return true, nil
 }
 

--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -208,6 +208,11 @@ func (p *v2Pusher) pushV2Tag(ctx context.Context, ref reference.NamedTagged, ima
 
 	manifestDigest := digest.FromBytes(canonicalManifest)
 	progress.Messagef(p.config.ProgressOutput, "", "%s: digest: %s size: %d", ref.Tag(), manifestDigest, len(canonicalManifest))
+
+	if err := addDigestReference(p.config.ReferenceStore, ref, manifestDigest, imageID); err != nil {
+		return err
+	}
+
 	// Signal digest to the trust client so it can sign the
 	// push, if appropriate.
 	progress.Aux(p.config.ProgressOutput, PushResult{Tag: ref.Tag(), Digest: manifestDigest, Size: len(canonicalManifest)})

--- a/integration-cli/docker_cli_authz_unix_test.go
+++ b/integration-cli/docker_cli_authz_unix_test.go
@@ -6,20 +6,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"strings"
 
 	"bufio"
 	"bytes"
+	"os/exec"
+	"strconv"
+	"time"
+
 	"github.com/docker/docker/pkg/authorization"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/docker/docker/pkg/plugins"
 	"github.com/go-check/check"
-	"os/exec"
-	"strconv"
-	"time"
 )
 
 const (

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -389,10 +389,15 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 	dockerCmd(c, "pull", imageReference)
 	// just in case...
 
+	dockerCmd(c, "tag", imageReference, repoName+":sometag")
+
 	imageID, err := inspectField(imageReference, "Id")
 	c.Assert(err, checker.IsNil, check.Commentf("error inspecting image id"))
 
 	dockerCmd(c, "rmi", imageID)
+
+	_, err = inspectFieldWithError(imageID, "Id")
+	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }
 
 func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(c *check.C) {
@@ -421,6 +426,40 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndTag(c *check.C) {
 
 	// rmi should have deleted the tag, the digest reference, and the image itself
 	_, err = inspectField(imageID, "Id")
+	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
+}
+
+func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndMultiRepoTag(c *check.C) {
+	pushDigest, err := setupImage(c)
+	c.Assert(err, checker.IsNil, check.Commentf("error setting up image"))
+
+	repo2 := fmt.Sprintf("%s/%s", repoName, "repo2")
+
+	// pull from the registry using the <name>@<digest> reference
+	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
+	dockerCmd(c, "pull", imageReference)
+
+	imageID := inspectField(c, imageReference, "Id")
+
+	repoTag := repoName + ":sometag"
+	repoTag2 := repo2 + ":othertag"
+	dockerCmd(c, "tag", imageReference, repoTag)
+	dockerCmd(c, "tag", imageReference, repoTag2)
+
+	dockerCmd(c, "rmi", repoTag)
+
+	// rmi should have deleted repoTag and image reference, but left repoTag2
+	inspectField(c, repoTag2, "Id")
+	_, err = inspectFieldWithError(imageReference, "Id")
+	c.Assert(err, checker.NotNil, check.Commentf("image digest reference should have been removed"))
+
+	_, err = inspectFieldWithError(repoTag, "Id")
+	c.Assert(err, checker.NotNil, check.Commentf("image tag reference should have been removed"))
+
+	dockerCmd(c, "rmi", repoTag2)
+
+	// rmi should have deleted the tag, the digest reference, and the image itself
+	_, err = inspectFieldWithError(imageID, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -291,10 +291,8 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
-	reWithTag1 := regexp.MustCompile(`\s*` + repoName + `\s*tag1\s*<none>\s`)
-	reWithDigest1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1.String() + `\s`)
+	reWithDigest1 := regexp.MustCompile(`\s*` + repoName + `\s*tag1\s*` + digest1.String() + `\s`)
 	c.Assert(reWithDigest1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest1.String(), out))
-	c.Assert(reWithTag1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithTag1.String(), out))
 	// make sure image 2 has repo, <none>, digest
 	c.Assert(re2.MatchString(out), checker.True, check.Commentf("expected %q: %s", re2.String(), out))
 
@@ -305,21 +303,19 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
-	c.Assert(reWithTag1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithTag1.String(), out))
+	c.Assert(reWithDigest1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest1.String(), out))
 
 	// make sure image 2 has repo, tag, digest
-	reWithTag2 := regexp.MustCompile(`\s*` + repoName + `\s*tag2\s*<none>\s`)
-	reWithDigest2 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest2.String() + `\s`)
-	c.Assert(reWithTag2.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithTag2.String(), out))
+	reWithDigest2 := regexp.MustCompile(`\s*` + repoName + `\s*tag2\s*` + digest2.String() + `\s`)
 	c.Assert(reWithDigest2.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest2.String(), out))
 
 	// list images
 	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
-	c.Assert(reWithTag1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithTag1.String(), out))
+	c.Assert(reWithDigest1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest1.String(), out))
 	// make sure image 2 has repo, tag, digest
-	c.Assert(reWithTag2.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithTag2.String(), out))
+	c.Assert(reWithDigest2.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest2.String(), out))
 	// make sure busybox has tag, but not digest
 	busyboxRe := regexp.MustCompile(`\s*busybox\s*latest\s*<none>\s`)
 	c.Assert(busyboxRe.MatchString(out), checker.True, check.Commentf("expected %q: %s", busyboxRe.String(), out))

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -469,7 +469,7 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 
 	dockerCmd(c, "rmi", imageID)
 
-	_, err = inspectFieldWithError(imageID, "Id")
+	_, err = inspectField(imageID, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }
 
@@ -512,7 +512,8 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndMultiRepoTag(c *check.
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 	dockerCmd(c, "pull", imageReference)
 
-	imageID := inspectField(c, imageReference, "Id")
+	imageID, err := inspectField(imageReference, "Id")
+	c.Assert(err, checker.IsNil)
 
 	repoTag := repoName + ":sometag"
 	repoTag2 := repo2 + ":othertag"
@@ -522,17 +523,17 @@ func (s *DockerRegistrySuite) TestDeleteImageWithDigestAndMultiRepoTag(c *check.
 	dockerCmd(c, "rmi", repoTag)
 
 	// rmi should have deleted repoTag and image reference, but left repoTag2
-	inspectField(c, repoTag2, "Id")
-	_, err = inspectFieldWithError(imageReference, "Id")
+	inspectField(repoTag2, "Id")
+	_, err = inspectField(imageReference, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image digest reference should have been removed"))
 
-	_, err = inspectFieldWithError(repoTag, "Id")
+	_, err = inspectField(repoTag, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image tag reference should have been removed"))
 
 	dockerCmd(c, "rmi", repoTag2)
 
 	// rmi should have deleted the tag, the digest reference, and the image itself
-	_, err = inspectFieldWithError(imageID, "Id")
+	_, err = inspectField(imageID, "Id")
 	c.Assert(err, checker.NotNil, check.Commentf("image should have been deleted"))
 }
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -325,6 +325,79 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	c.Assert(busyboxRe.MatchString(out), checker.True, check.Commentf("expected %q: %s", busyboxRe.String(), out))
 }
 
+func (s *DockerRegistrySuite) TestListDanglingImagesWithDigests(c *check.C) {
+	// setup image1
+	digest1, err := setupImageWithTag(c, "dangle1")
+	c.Assert(err, checker.IsNil, check.Commentf("error setting up image"))
+	imageReference1 := fmt.Sprintf("%s@%s", repoName, digest1)
+	c.Logf("imageReference1 = %s", imageReference1)
+
+	// pull image1 by digest
+	dockerCmd(c, "pull", imageReference1)
+
+	// list images
+	out, _ := dockerCmd(c, "images", "--digests")
+
+	// make sure repo shown, tag=<none>, digest = $digest1
+	re1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1.String() + `\s`)
+	c.Assert(re1.MatchString(out), checker.True, check.Commentf("expected %q: %s", re1.String(), out))
+	// setup image2
+	digest2, err := setupImageWithTag(c, "dangle2")
+	//error setting up image
+	c.Assert(err, checker.IsNil)
+	imageReference2 := fmt.Sprintf("%s@%s", repoName, digest2)
+	c.Logf("imageReference2 = %s", imageReference2)
+
+	// pull image1 by digest
+	dockerCmd(c, "pull", imageReference1)
+
+	// pull image2 by digest
+	dockerCmd(c, "pull", imageReference2)
+
+	// list images
+	out, _ = dockerCmd(c, "images", "--digests", "--filter=\"dangling=true\"")
+
+	// make sure repo shown, tag=<none>, digest = $digest1
+	c.Assert(re1.MatchString(out), checker.True, check.Commentf("expected %q: %s", re1.String(), out))
+
+	// make sure repo shown, tag=<none>, digest = $digest2
+	re2 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest2.String() + `\s`)
+	c.Assert(re2.MatchString(out), checker.True, check.Commentf("expected %q: %s", re2.String(), out))
+
+	// pull dangle1 tag
+	dockerCmd(c, "pull", repoName+":dangle1")
+
+	// list images
+	out, _ = dockerCmd(c, "images", "--digests", "--filter=\"dangling=true\"")
+
+	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
+	reWithDigest1 := regexp.MustCompile(`\s*` + repoName + `\s*dangle1\s*` + digest1.String() + `\s`)
+	c.Assert(reWithDigest1.MatchString(out), checker.False, check.Commentf("unexpected %q: %s", reWithDigest1.String(), out))
+	// make sure image 2 has repo, <none>, digest
+	c.Assert(re2.MatchString(out), checker.True, check.Commentf("expected %q: %s", re2.String(), out))
+
+	// pull dangle2 tag
+	dockerCmd(c, "pull", repoName+":dangle2")
+
+	// list images, show tagged images
+	out, _ = dockerCmd(c, "images", "--digests")
+
+	// make sure image 1 has repo, tag, digest
+	c.Assert(reWithDigest1.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest1.String(), out))
+
+	// make sure image 2 has repo, tag, digest
+	reWithDigest2 := regexp.MustCompile(`\s*` + repoName + `\s*dangle2\s*` + digest2.String() + `\s`)
+	c.Assert(reWithDigest2.MatchString(out), checker.True, check.Commentf("expected %q: %s", reWithDigest2.String(), out))
+
+	// list images, no longer dangling, should not match
+	out, _ = dockerCmd(c, "images", "--digests", "--filter=\"dangling=true\"")
+
+	// make sure image 1 has repo, tag, digest
+	c.Assert(reWithDigest1.MatchString(out), checker.False, check.Commentf("unexpected %q: %s", reWithDigest1.String(), out))
+	// make sure image 2 has repo, tag, digest
+	c.Assert(reWithDigest2.MatchString(out), checker.False, check.Commentf("unexpected %q: %s", reWithDigest2.String(), out))
+}
+
 func (s *DockerRegistrySuite) TestInspectImageWithDigests(c *check.C) {
 	digest, err := setupImage(c)
 	c.Assert(err, check.IsNil, check.Commentf("error setting up image"))

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -9,14 +9,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/docker/distribution/digest"
 	"github.com/docker/distribution/reference"
-	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/integration/checker"
 	"github.com/go-check/check"
 )
@@ -290,7 +288,7 @@ func (s *DockerTrustSuite) TestTrustedPush(c *check.C) {
 	s.trustedCmd(pullCmd)
 	out, _, err = runCommandWithOutput(pullCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+	c.Assert(string(out), checker.Contains, "Status: Image is up to date", check.Commentf(out))
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {
@@ -309,7 +307,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithEnvPasswords(c *check.C) {
 	s.trustedCmd(pullCmd)
 	out, _, err = runCommandWithOutput(pullCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+	c.Assert(string(out), checker.Contains, "Status: Image is up to date", check.Commentf(out))
 }
 
 // This test ensures backwards compatibility with old ENV variables. Should be
@@ -367,7 +365,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithExistingTag(c *check.C) {
 	s.trustedCmd(pullCmd)
 	out, _, err = runCommandWithOutput(pullCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
+	c.Assert(string(out), checker.Contains, "Status: Image is up to date", check.Commentf(out))
 }
 
 func (s *DockerTrustSuite) TestTrustedPushWithExistingSignedTag(c *check.C) {
@@ -514,16 +512,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithReleasesDelegation(c *check.C) {
 	s.trustedCmd(pullCmd)
 	out, _, err = runCommandWithOutput(pullCmd)
 	c.Assert(err, check.IsNil, check.Commentf(out))
-	c.Assert(string(out), checker.Contains, "Status: Downloaded", check.Commentf(out))
-
-	// check to make sure that the target has been added to targets/releases and not targets
-	contents, err := ioutil.ReadFile(filepath.Join(cliconfig.ConfigDir(), "trust/tuf", repoName, "metadata/targets.json"))
-	c.Assert(err, check.IsNil, check.Commentf("Unable to read targets metadata"))
-	c.Assert(strings.Contains(string(contents), `"latest"`), checker.False, check.Commentf(string(contents)))
-
-	contents, err = ioutil.ReadFile(filepath.Join(cliconfig.ConfigDir(), "trust/tuf", repoName, "metadata/targets/releases.json"))
-	c.Assert(err, check.IsNil, check.Commentf("Unable to read targets/releases metadata"))
-	c.Assert(string(contents), checker.Contains, `"latest"`, check.Commentf(string(contents)))
+	c.Assert(string(out), checker.Contains, "Status: Image is up to date", check.Commentf(out))
 }
 
 func (s *DockerSuite) TestPushOfficialImage(c *check.C) {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -317,6 +317,11 @@ func (d *Daemon) StartWithBusybox(arg ...string) error {
 	if err := d.Start(arg...); err != nil {
 		return err
 	}
+	return d.LoadBusybox()
+}
+
+// LoadBusybox will load the stored busybox into a newly started daemon
+func (d *Daemon) LoadBusybox() error {
 	bb := filepath.Join(d.folder, "busybox.tar")
 	if _, err := os.Stat(bb); err != nil {
 		if !os.IsNotExist(err) {
@@ -538,11 +543,11 @@ func (d *Daemon) getAndTestImageEntry(c *check.C, expectedImageCount int, repoNa
 	if expectedImageCount >= 0 && len(images) != expectedImageCount {
 		switch expectedImageCount {
 		case 0:
-			c.Fatalf("expected empty local image database, got %d images", len(images))
+			c.Fatalf("expected empty local image database, got %d images: %v", len(images), images)
 		case 1:
-			c.Fatalf("expected exactly 1 local image, got %d", len(images))
+			c.Fatalf("expected exactly 1 local image, got %d: %v", len(images), images)
 		default:
-			c.Fatalf("expected exactly %d local images, got %d", expectedImageCount, len(images))
+			c.Fatalf("expected exactly %d local images, got %d: %v", expectedImageCount, len(images), images)
 		}
 	}
 


### PR DESCRIPTION
@jwhonce @ncdc @rhatdan 

Discussed yesterday, I went ahead and backported those patches - integration tests run just fine (ran locally). Let me know if fedora-1.10.3 needs this as well.