### PR TITLE
fix retrieving stats when networking is disabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1485,8 +1485,10 @@ func (daemon *Daemon) GetContainerStats(container *container.Container) (*execdr
 
 	// Retrieve the nw statistics from libnetwork and inject them in the Stats
 	var nwStats []*libcontainer.NetworkInterface
-	if nwStats, err = daemon.getNetworkStats(container); err != nil {
-		return nil, err
+	if !container.Config.NetworkDisabled {
+		if nwStats, err = daemon.getNetworkStats(container); err != nil {
+			return nil, err
+		}
 	}
 	stats.Interfaces = nwStats
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1374265

resolves rhbz#1374265
resolves https://github.com/docker/docker-py/issues/1195