### PR TITLE
Attempt to mimic changes from upstream PR#27467

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -204,7 +204,7 @@ func (d *Daemon) ContainerExecStart(ctx context.Context, name string, stdin io.R
 
 	attachErr := container.AttachStreams(ctx, ec.StreamConfig, ec.OpenStdin, true, ec.Tty, cStdin, cStdout, cStderr, ec.DetachKeys)
 
-	if err := d.containerd.AddProcess(ctx, c.ID, name, p); err != nil {
+	if err := d.containerd.AddProcess(ctx, c.ID, name, p, d.AttachExecStreams(ec)); err != nil {
 		return err
 	}
 

--- a/libcontainerd/client_solaris.go
+++ b/libcontainerd/client_solaris.go
@@ -8,7 +8,7 @@ type client struct {
 	// Platform specific properties below here.
 }
 
-func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, specp Process) error {
+func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, specp Process, attachStdio ProcessStreamAttacher) error {
 	return nil
 }
 
@@ -29,6 +29,10 @@ func (clnt *client) Pause(containerID string) error {
 }
 
 func (clnt *client) Resume(containerID string) error {
+	return nil
+}
+
+func (clnt *client) SignalProcess(containerID string, processFriendlyName string, sig int) error {
 	return nil
 }
 

--- a/libcontainerd/client_windows.go
+++ b/libcontainerd/client_windows.go
@@ -171,7 +171,7 @@ func (clnt *client) Create(containerID string, spec Spec, options ...CreateOptio
 
 // AddProcess is the handler for adding a process to an already running
 // container. It's called through docker exec.
-func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, procToAdd Process) error {
+func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, procToAdd Process, attachStdio ProcessStreamAttacher) error {
 	clnt.lock(containerID)
 	defer clnt.unlock(containerID)
 	container, err := clnt.getContainer(containerID)
@@ -254,7 +254,7 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 	clnt.unlock(containerID)
 
 	// Tell the engine to attach streams back to the client
-	if err := clnt.backend.AttachStreams(processFriendlyName, *iopipe); err != nil {
+	if err := attachStdio(processFriendlyName, *iopipe); err != nil {
 		clnt.lock(containerID)
 		return err
 	}

--- a/libcontainerd/container_linux.go
+++ b/libcontainerd/container_linux.go
@@ -116,7 +116,7 @@ func (ctr *container) start() error {
 	}
 	ctr.startedAt = time.Now()
 
-	if err := ctr.client.backend.AttachStreams(ctr.containerID, *iopipe); err != nil {
+	if err := ctr.client.backend.AttachContainerStreams(ctr.containerID, *iopipe); err != nil {
 		return err
 	}
 	ctr.systemPid = systemPid(resp.Container)

--- a/libcontainerd/container_windows.go
+++ b/libcontainerd/container_windows.go
@@ -142,7 +142,7 @@ func (ctr *container) start() error {
 
 	ctr.client.appendContainer(ctr)
 
-	if err := ctr.client.backend.AttachStreams(ctr.containerID, *iopipe); err != nil {
+	if err := ctr.client.backend.AttachContainerStreams(ctr.containerID, *iopipe); err != nil {
 		// OK to return the error here, as waitExit will handle tear-down in HCS
 		return err
 	}

--- a/libcontainerd/types.go
+++ b/libcontainerd/types.go
@@ -31,15 +31,17 @@ type CommonStateInfo struct { // FIXME: event?
 // Backend defines callbacks that the client of the library needs to implement.
 type Backend interface {
 	StateChanged(containerID string, state StateInfo) error
-	AttachStreams(processFriendlyName string, io IOPipe) error
+	AttachContainerStreams(processFriendlyName string, io IOPipe) error
 }
+
+type ProcessStreamAttacher func(processFriendlyName string, io IOPipe) error
 
 // Client provides access to containerd features.
 type Client interface {
 	Create(containerID string, spec Spec, options ...CreateOption) error
 	Signal(containerID string, sig int) error
 	SignalProcess(containerID string, processFriendlyName string, sig int) error
-	AddProcess(ctx context.Context, containerID, processFriendlyName string, process Process) error
+	AddProcess(ctx context.Context, containerID, processFriendlyName string, process Process, attachStdio ProcessStreamAttacher) error
 	Resize(containerID, processFriendlyName string, width, height int) error
 	Pause(containerID string) error
 	Resume(containerID string) error


### PR DESCRIPTION
Problem: if a process that's been started for 'docker exec' exits fast enough, the daemon can receive a 'process exited' update from containerd before it starts passing stdio data back and forth, losing its output.

Why it happens: the 'process exited' state change message is only processed after acquiring a lock for the container, and while most of the exec() setup is done while holding that lock, the lock is freed when libcontainerd calls back to set up the passing of stdio data.

Proposed change: call getExecConfig() before AddProcess(), and modify AddProcess() to take a callback that the daemon can hand it that remembers the exec.Config value that was retrieved.

The effect should be comparable to the changes in https://github.com/docker/docker/pull/27467 (in that we now hold the libcontainerd client lock, and make sure that we don't obtain the Container object's lock by calling getExecConfig()), but without additional refactoring.
