### PR TITLE
Add daemon flag --enable-secrets.

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -868,6 +868,7 @@ _docker_daemon() {
 	local boolean_options="
 		$global_boolean_options
 		--disable-legacy-registry
+		--enable-secrets=true
 		--help
 		--icc=false
 		--ip-forward=false

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -94,6 +94,7 @@ type CommonConfig struct {
 	TrustKeyPath         string              `json:"-"`
 	CorsHeaders          string              `json:"api-cors-header,omitempty"`
 	EnableCors           bool                `json:"api-enable-cors,omitempty"`
+	EnableSecrets        bool                `json:"enable-secrets,omitempty"`
 	LiveRestore          bool                `json:"live-restore,omitempty"`
 	BlockedRegistries    []string            `json:"block-registry,omitempty"`
 	AdditionalRegistries []string            `json:"add-registry,omitempty"`

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -87,6 +87,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.bridgeConfig.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.StringVar(&config.bridgeConfig.UserlandProxyPath, []string{"-userland-proxy-path"}, "", "Path to the userland proxy binary")
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
+	cmd.BoolVar(&config.EnableSecrets, []string{"-enable-secrets"}, true, usageFn("Enable Secrets"))
 	cmd.StringVar(&config.CgroupParent, []string{"-cgroup-parent"}, "", usageFn("Set parent cgroup for all containers"))
 	cmd.StringVar(&config.RemappedRoot, []string{"-userns-remap"}, "", usageFn("User/Group setting for user namespaces"))
 	cmd.StringVar(&config.ContainerdAddr, []string{"-containerd"}, "", usageFn("Path to containerd socket"))

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -665,14 +665,16 @@ func (daemon *Daemon) createSpec(c *container.Container) (*libcontainerd.Spec, e
 	ms = append(ms, c.IpcMounts()...)
 	ms = append(ms, c.TmpfsMounts()...)
 	rootUID, rootGID := daemon.GetRemappedUIDGID()
-	m, err := c.SecretMount(rootUID, rootGID)
-	if err != nil {
-		return nil, err
-	}
-	// SecretMount() returns m == nil && err == nil
-	// we check m before appending and dereferencing it
-	if m != nil {
-		ms = append(ms, *m)
+	if daemon.configStore.EnableSecrets {
+		m, err := c.SecretMount(rootUID, rootGID)
+		if err != nil {
+			return nil, err
+		}
+		// SecretMount() returns m == nil && err == nil
+		// we check m before appending and dereferencing it
+		if m != nil {
+			ms = append(ms, *m)
+		}
 	}
 	sort.Sort(mounts(ms))
 	if err := setMounts(daemon, &s, c, ms); err != nil {

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -39,6 +39,7 @@ Options:
       --dns=[]                               DNS server to use
       --dns-opt=[]                           DNS options to use
       --dns-search=[]                        DNS search domains to use
+      --enable-secrets=true                  Enable Secrets
       --exec-opt=[]                          Runtime execution options
       --exec-root=/var/run/docker            Root directory for execution state files
       --fixed-cidr                           IPv4 subnet for fixed IPs
@@ -1020,6 +1021,7 @@ This is a full example of the allowed configuration options on Linux:
 	"dns": [],
 	"dns-opts": [],
 	"dns-search": [],
+	"enable-secrets": true,
 	"exec-opts": [],
 	"exec-root": "",
 	"storage-driver": "",

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -27,6 +27,7 @@ dockerd - Enable daemon mode
 [**--dns**[=*[]*]]
 [**--dns-opt**[=*[]*]]
 [**--dns-search**[=*[]*]]
+[**--enable-secrets**[=*true*]]
 [**--exec-opt**[=*[]*]]
 [**--exec-root**[=*/var/run/docker*]]
 [**--fixed-cidr**[=*FIXED-CIDR*]]
@@ -144,6 +145,9 @@ format.
 **--dns-search**=[]
   DNS search domains to use.
 
+**--enable-secrets**=*true*|*false*
+  Allow subscription-manager inside the containers to use subscriptions available on the host. Default is true.
+  
 **--exec-opt**=[]
   Set runtime execution options. See RUNTIME EXECUTION OPTIONS.
 


### PR DESCRIPTION
This flag (--enable-secrets) is enabled by default. It allows subscription-manager inside the containers to use subscriptions available on the host.

Signed-off-by: Shishir Mahajan <shishir.mahajan@redhat.com>