### PR TITLE
We need to fix labels if the user requests on volumes

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -152,6 +152,11 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			if bind.Driver == volume.DefaultDriverName {
 				setBindModeIfNull(bind)
 			}
+			if label.RelabelNeeded(bind.Mode) {
+				if err := label.Relabel(bind.Source, container.MountLabel, label.IsShared(bind.Mode)); err != nil {
+					return err
+				}
+			}
 		}
 
 		binds[bind.Destination] = true


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**


urrently local volumes and other volumes that support SELinux do
not get labeled correctly. This patch will allow a user to specify
:Z or :z when mounting a volume and have it fix the label of the newly
created volume.

Signed-off-by: Dan Walsh dwalsh@redhat.com

Signed-off-by: Dan Walsh <dwalsh@redhat.com>