### PR TITLE
journald logs: drain 1 more time at container exit

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -259,6 +259,13 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 			errstr := C.GoString(cerrstr)
 			fmtstr := "error %q while attempting to follow journal for container %q"
 			logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+		} else {
+			// In the event that we were told to stop (logWatcher.WatchClose() below), it's possible
+			// there's more data in the journal for this container that was written just as the container
+			// exited. Try to drain the journal one more time to pick up any last-minute journal entries.
+			// Note, this isn't fool-proof and there's no guarantee that we'll get all the trailing
+			// entries, but this is better than nothing, as it does yield entries more often than not.
+			s.drainJournal(logWatcher, config, j, cursor)
 		}
 		// Clean up.
 		C.close(pfd[0])


### PR DESCRIPTION
In the journald log driver, attempt to drain the journal 1 more time
after being told to stop following the log. Due to a possible race
condition, sometimes data is written to the journal at almost the same
time the log watch is closed, and depending on the order of operations,
sometimes you miss the last journal entry.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

