### PR TITLE
[1.12.6] Always HEAD blobs at least once during pushes

### DIFF
--- a/distribution/push_v2.go
+++ b/distribution/push_v2.go
@@ -311,8 +311,8 @@ func (pd *v2PushDescriptor) Upload(ctx context.Context, progressOutput progress.
 	// Do we have any metadata associated with this layer's DiffID?
 	v2Metadata, err := pd.v2MetadataService.GetMetadata(diffID)
 	if err == nil {
-		// check for blob existence in the target repository if we have a mapping with it
-		descriptor, exists, err := pd.layerAlreadyExists(ctx, progressOutput, diffID, false, 1, v2Metadata)
+		// check for blob existence in the target repository
+		descriptor, exists, err := pd.layerAlreadyExists(ctx, progressOutput, diffID, true, 1, v2Metadata)
 		if exists || err != nil {
 			return descriptor, err
 		}


### PR DESCRIPTION
This lowers a chance of unnecessary blob re-upload.

Original upstream PR: https://github.com/docker/docker/pull/31720