### PR TITLE
[1.12.6] BACKPORT: Remove timeout on fifos opening

### DIFF
--- a/libcontainerd/client_linux.go
+++ b/libcontainerd/client_linux.go
@@ -34,7 +34,7 @@ type client struct {
 // AddProcess is the handler for adding a process to an already running
 // container. It's called through docker exec. It returns the system pid of the
 // exec'd process.
-func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, specp Process, attachStdio StdioCallback) error {
+func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendlyName string, specp Process, attachStdio StdioCallback) (err error) {
 	clnt.lock(containerID)
 	defer clnt.unlock(containerID)
 	container, err := clnt.getContainer(containerID)
@@ -90,7 +90,14 @@ func (clnt *client) AddProcess(ctx context.Context, containerID, processFriendly
 		Rlimits:         convertRlimits(sp.Rlimits),
 	}
 
-	iopipe, err := p.openFifos(sp.Terminal)
+	fifoCtx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
+	iopipe, err := p.openFifos(fifoCtx, sp.Terminal)
 	if err != nil {
 		return err
 	}
@@ -433,7 +440,14 @@ func (clnt *client) restore(cont *containerd.Container, lastEvent *containerd.Ev
 		}
 	}
 
-	iopipe, err := container.openFifos(terminal)
+	fifoCtx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
+	iopipe, err := container.openFifos(fifoCtx, terminal)
 	if err != nil {
 		return err
 	}

--- a/libcontainerd/process_linux.go
+++ b/libcontainerd/process_linux.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	containerd "github.com/docker/containerd/api/grpc/types"
 	"github.com/tonistiigi/fifo"
@@ -27,12 +26,10 @@ type process struct {
 	dir string
 }
 
-func (p *process) openFifos(terminal bool) (pipe *IOPipe, err error) {
+func (p *process) openFifos(ctx context.Context, terminal bool) (pipe *IOPipe, err error) {
 	if err := os.MkdirAll(p.dir, 0700); err != nil {
 		return nil, err
 	}
-
-	ctx, _ := context.WithTimeout(context.Background(), 15*time.Second)
 
 	io := &IOPipe{}
 


### PR DESCRIPTION
Upstream reference: https://github.com/moby/moby/pull/30140

Fix BZ https://bugzilla.redhat.com/show_bug.cgi?id=1427212

@rhatdan @jwhonce @imcleod @nalind PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>