### PR TITLE
Fix potential double-frees in the journal log reader

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -237,7 +237,10 @@ drain:
 
 	// free(NULL) is safe
 	C.free(unsafe.Pointer(oldCursor))
-	C.sd_journal_get_cursor(j, &cursor)
+	if C.sd_journal_get_cursor(j, &cursor) != 0 {
+		// ensure that we won't be freeing an address that's invalid
+		cursor = nil
+	}
 	return cursor
 }
 
@@ -271,7 +274,6 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 		s.readers.mu.Lock()
 		delete(s.readers.readers, logWatcher)
 		s.readers.mu.Unlock()
-		C.sd_journal_close(j)
 		close(logWatcher.Msg)
 	}()
 	// Wait until we're told to stop.
@@ -305,9 +307,9 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	following := false
 	defer func(pfollowing *bool) {
 		if !*pfollowing {
-			C.sd_journal_close(j)
 			close(logWatcher.Msg)
 		}
+		C.sd_journal_close(j)
 	}(&following)
 	// Remove limits on the size of data items that we'll retrieve.
 	rc = C.sd_journal_set_data_threshold(j, C.size_t(0))

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -248,6 +248,9 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 	s.readers.mu.Lock()
 	s.readers.readers[logWatcher] = logWatcher
 	s.readers.mu.Unlock()
+
+	newCursor := make(chan *C.char)
+
 	go func() {
 		// Keep copying journal data out until we're notified to stop
 		// or we hit an error.
@@ -275,6 +278,7 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 		delete(s.readers.readers, logWatcher)
 		s.readers.mu.Unlock()
 		close(logWatcher.Msg)
+		newCursor <- cursor
 	}()
 	// Wait until we're told to stop.
 	select {
@@ -282,6 +286,8 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 		// Notify the other goroutine that its work is done.
 		C.close(pfd[1])
 	}
+
+	cursor = <-newCursor
 
 	return cursor
 }


### PR DESCRIPTION
This PR backports a couple of fixes from upstream which aim to avoid freeing of invalid pointers, from https://github.com/moby/moby/pull/31231 and https://github.com/moby/moby/pull/31263.