### PR TITLE
Overlay selinux support check

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -608,11 +609,56 @@ func configureMaxThreads(config *Config) error {
 	return nil
 }
 
+func overlaySupportsSelinux() (bool, error) {
+	f, err := os.Open("/proc/kallsyms")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close()
+
+	var symAddr, symType, symName, text string
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return false, err
+		}
+
+		text = s.Text()
+		if _, err := fmt.Sscanf(text, "%s %s %s", &symAddr, &symType, &symName); err != nil {
+			return false, fmt.Errorf("Scanning '%s' failed: %s", text, err)
+		}
+
+		// Check for presence of symbol security_inode_copy_up.
+		if symName == "security_inode_copy_up" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // configureKernelSecuritySupport configures and validates security support for the kernel
 func configureKernelSecuritySupport(config *Config, driverName string) error {
 	if config.EnableSelinuxSupport {
 		if !selinuxEnabled() {
 			logrus.Warn("Docker could not enable SELinux on the host system")
+			return nil
+		}
+
+		if driverName == "overlay" || driverName == "overlay2" {
+			// If driver is overlay or overlay2, make sure kernel
+			// supports selinux with overlay.
+			supported, err := overlaySupportsSelinux()
+			if err != nil {
+				return err
+			}
+
+			if !supported {
+				logrus.Warnf("SELinux is not supported with the %s graph driver on this kernel", driverName)
+			}
 		}
 	} else {
 		selinuxSetDisabled()

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -657,7 +657,7 @@ func configureKernelSecuritySupport(config *Config, driverName string) error {
 			}
 
 			if !supported {
-				logrus.Warnf("SELinux is not supported with the %s graph driver on this kernel", driverName)
+				logrus.Errorf("SELinux is not supported with the %s graph driver on this kernel. Either boot into a newer kernel or disable selinux in docker (--selinux-enabled=false)", driverName)
 			}
 		}
 	} else {


### PR DESCRIPTION
This series does two things.

First it backports a patch from upstream to check if kernel supports selinux with overlay/overlay2 or not.

Secondly, it adds one more patch and converts warning into error. Upstream only warns is selinux is enabled in docker but kernel does not support it with overlay. We would rather like to error out and let user fix the configuration.