### PR TITLE
Fixes bug 1450912 - docker-search man page typos of 'stars'

### DIFF
--- a/man/docker-search.1.md
+++ b/man/docker-search.1.md
@@ -49,7 +49,7 @@ of stars awarded, whether the image is official, and whether it is automated.
 Search a registry for the term 'fedora' and only display those images
 ranked 3 or higher:
 
-    $ docker search --filter=starts=3 fedora
+    $ docker search --filter=stars=3 fedora
     INDEX      NAME                            DESCRIPTION                                    STARS OFFICIAL  AUTOMATED
     docker.io  docker.io/mattdm/fedora         A basic Fedora image corresponding roughly...  50
     docker.io  docker.io/fedora                (Semi) Official Fedora base image.             38
@@ -61,7 +61,7 @@ ranked 3 or higher:
 Search Docker Hub for the term 'fedora' and only display automated images
 ranked 1 or higher:
 
-    $ docker search --filter=is-automated=true --filter=starts=1 fedora
+    $ docker search --filter=is-automated=true --filter=stars=1 fedora
     INDEX      NAME                         DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
     docker.io  docker.io/goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
     docker.io  docker.io/tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]


### PR DESCRIPTION
Signed-off-by: umohnani8 <umohnani@redhat.com>
Fixes bug 1450912 - https://bugzilla.redhat.com/show_bug.cgi?id=1450912
Man page examples had typos where "starts" was used instead of "stars"


