### PR TITLE
Add support for --network=netns:/proc/pid/ns/net

### DIFF
--- a/daemon/container_operations.go
+++ b/daemon/container_operations.go
@@ -339,7 +339,7 @@ func (daemon *Daemon) updateContainerNetworkSettings(container *container.Contai
 	)
 
 	mode := container.HostConfig.NetworkMode
-	if container.Config.NetworkDisabled || mode.IsContainer() {
+	if container.Config.NetworkDisabled || mode.IsContainer() || mode.IsNetNs() {
 		return nil
 	}
 
@@ -397,7 +397,7 @@ func (daemon *Daemon) allocateNetwork(container *container.Container) error {
 
 	updateSettings := false
 	if len(container.NetworkSettings.Networks) == 0 {
-		if container.Config.NetworkDisabled || container.HostConfig.NetworkMode.IsContainer() {
+		if container.Config.NetworkDisabled || container.HostConfig.NetworkMode.IsContainer() || container.HostConfig.NetworkMode.IsNetNs() {
 			return nil
 		}
 
@@ -729,7 +729,7 @@ func (daemon *Daemon) releaseNetwork(container *container.Container) {
 	if daemon.netController == nil {
 		return
 	}
-	if container.HostConfig.NetworkMode.IsContainer() || container.Config.NetworkDisabled {
+	if container.HostConfig.NetworkMode.IsContainer() || container.HostConfig.NetworkMode.IsNetNs() || container.Config.NetworkDisabled {
 		return
 	}
 

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -270,6 +270,8 @@ func setNamespaces(daemon *Daemon, s *specs.Spec, c *container.Container) error 
 				nsUser.Path = fmt.Sprintf("/proc/%d/ns/user", nc.State.GetPID())
 				setNamespace(s, nsUser)
 			}
+		} else if parts[0] == "netns" {
+			ns.Path = parts[1]
 		} else if c.HostConfig.NetworkMode.IsHost() {
 			ns.Path = c.NetworkSettings.SandboxKey
 		}

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -35,6 +35,13 @@ func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
 			return fmt.Errorf("--net: invalid net mode: invalid container format container:<name|id>")
 		}
 	}
+	if parts[0] == "netns" {
+		if len(parts) < 2 || parts[1] == "" {
+			return fmt.Errorf("--net: invalid net mode: invalid netns format netns:/path/to/netns")
+		} else {
+			return nil
+		}
+	}
 
 	if hc.NetworkMode.IsContainer() && c.Hostname != "" {
 		return ErrConflictNetworkHostname

--- a/vendor/src/github.com/docker/engine-api/types/container/hostconfig_unix.go
+++ b/vendor/src/github.com/docker/engine-api/types/container/hostconfig_unix.go
@@ -53,6 +53,12 @@ func (n NetworkMode) IsContainer() bool {
 	return len(parts) > 1 && parts[0] == "container"
 }
 
+// IsNetNs indicates whether container uses a container network namespace path.
+func (n NetworkMode) IsNetNs() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "netns"
+}
+
 // IsNone indicates whether container isn't using a network stack.
 func (n NetworkMode) IsNone() bool {
 	return n == "none"


### PR DESCRIPTION
To test this run a cri-o container and then get its pid and pass --network=netns:/proc/pid/ns/net of the cri-o container. You should then see the same `ip a` output inside both these containers.

@rhatdan @runcom 

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>

cc: @lsm5 we need a new rpm as soon as this is merged.

