### PR TITLE
Add support for --network=netns:/proc/pid/ns/net

### DIFF
--- a/api/types/container/host_config.go
+++ b/api/types/container/host_config.go
@@ -36,6 +36,12 @@ func (n IpcMode) IsHost() bool {
 	return n == "host"
 }
 
+// IsNetNs indicates whether container uses a container network namespace path.
+func (n NetworkMode) IsNetNs() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "netns"
+}
+
 // IsContainer indicates whether the container uses a container's ipc stack.
 func (n IpcMode) IsContainer() bool {
 	parts := strings.SplitN(string(n), ":", 2)

--- a/daemon/oci_linux.go
+++ b/daemon/oci_linux.go
@@ -251,6 +251,8 @@ func setNamespaces(daemon *Daemon, s *specs.Spec, c *container.Container) error 
 				nsUser.Path = fmt.Sprintf("/proc/%d/ns/user", nc.State.GetPID())
 				setNamespace(s, nsUser)
 			}
+		} else if c.HostConfig.NetworkMode.IsNetNs() {
+			ns.Path = parts[1]
 		} else if c.HostConfig.NetworkMode.IsHost() {
 			ns.Path = c.NetworkSettings.SandboxKey
 		}

--- a/runconfig/hostconfig_unix.go
+++ b/runconfig/hostconfig_unix.go
@@ -37,6 +37,14 @@ func ValidateNetMode(c *container.Config, hc *container.HostConfig) error {
 		}
 	}
 
+	if parts[0] == "netns" {
+		if len(parts) < 2 || parts[1] == "" {
+			return fmt.Errorf("--net: invalid net mode: invalid netns format netns:/path/to/netns")
+		} else {
+			return nil
+		}
+	}
+
 	if hc.NetworkMode.IsContainer() && c.Hostname != "" {
 		return ErrConflictNetworkHostname
 	}


### PR DESCRIPTION
This patch is the same as #271 but for 1.13.1 because I wasn't able to test for 1.12.6. This contains, however, some more stuff in `daemon/container_operations.go` (@mrunalp PTAL and update #271 accordingly).
The testing went fine:
```sh
# WITH CRI-O

$ sudo ./crioctl ctr execsync --id d03 ip a                 
Stdout:
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
3: eth0@if11: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue state UP
    link/ether 0a:58:0a:58:1a:37 brd ff:ff:ff:ff:ff:ff
    inet 10.88.26.55/16 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::a85c:a7ff:fed3:ee5b/64 scope link
       valid_lft forever preferred_lft forever

Stderr:

Exit code: 0

# WITH DOCKER

$ docker run -ti --network=netns:/var/run/netns/k8s_test3425234523fdadfsafdafa_redhat.test.crio_redhat-test-crio_1-b015acd2 busybox sh
/ # ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
3: eth0@if11: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1500 qdisc noqueue
    link/ether 0a:58:0a:58:1a:37 brd ff:ff:ff:ff:ff:ff
    inet 10.88.26.55/16 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::a85c:a7ff:fed3:ee5b/64 scope link
       valid_lft forever preferred_lft forever
```

You can see both containers in CRI-O and docker have the same IP address.

However, it's not clear in docker if the hostname is important. Right now, if you use this patch the docker container won't have the same hostname as the CRI-O container. I left a TODO here https://github.com/projectatomic/docker/compare/docker-1.13.1...runcom:netns-1.13?expand=1#diff-3a40f2cc412a64610c68b78a6bb97132R869

/cc @rhatdan @lsm5
@bparees @mrunalp Let me know if the hostname is important (I don't think so)

Signed-off-by: Antonio Murdaca <runcom@redhat.com>