### PR TITLE
BACKPORT: Add clarification to --privileged error message

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -532,7 +532,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *containertypes.
 	// check for various conflicting options with user namespaces
 	if daemon.configStore.RemappedRoot != "" && hostConfig.UsernsMode.IsPrivate() {
 		if hostConfig.Privileged {
-			return warnings, fmt.Errorf("Privileged mode is incompatible with user namespaces")
+			return warnings, fmt.Errorf("Privileged mode is incompatible with user namespaces. You must run the container in the host namespace (--userns=host) when running privileged mode.")
 		}
 		if hostConfig.NetworkMode.IsHost() && !hostConfig.UsernsMode.IsHost() {
 			return warnings, fmt.Errorf("Cannot share the host's network namespace when user namespaces are enabled")


### PR DESCRIPTION
A trivial backport of a trivial patch moby#33722 originally from Tom Sweeney clarifies the error message about incompatibility between --privileged and user namespaces.

Signed-off-by: Frantisek Kluknavsky <fkluknav@redhat.com>