### PR TITLE
Put start/exec/create/remove event in debug to lower log spam 1-13.1-…

### DIFF
--- a/api/server/middleware/audit_linux.go
+++ b/api/server/middleware/audit_linux.go
@@ -267,13 +267,13 @@ func logAction(w http.ResponseWriter, r *http.Request, d *daemon.Daemon) error {
 		message = fmt.Sprintf("ID=%v, %s", c.ID, message)
 	}
 	message = fmt.Sprintf("{Action=%v, %s}", action, message)
-	// Log info messages at Debug Level
-	// Log messages that change state at Info level
+	// Log messages at Debug Level
+	// Log messages that change state in Audit log
 	switch action {
 	case "history", "events", "stats", "search", "json", "version", "images", "info":
 		logrus.Debug(message)
 	default:
-		logrus.Info(message)
+		logrus.Debug(message)
 		logAuditlog(c, action, username, loginuid, true)
 	}
 	return nil


### PR DESCRIPTION
…rhel

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added start, exec, create and remove events to the list of actions to be logged only with debug logging.

**- How I did it**
Changed api/server/middleware/audit_linux.go

**- How to verify it**
Log files will no longer contain those actions unless debug logging is enabled.

**- Description for the changelog**
<!--
Move start, exec, create and remove actions to debug level logging.
-->

