### PR TITLE
Add mountlabel to diff drivers

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -362,7 +362,7 @@ func (a *Driver) Put(id string) error {
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (a *Driver) Diff(id, parent string) (archive.Archive, error) {
+func (a *Driver) Diff(id, parent, mountlabel string) (archive.Archive, error) {
 	// AUFS doesn't need the parent layer to produce a diff.
 	return archive.TarWithOptions(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
 		Compression:     archive.Uncompressed,
@@ -397,7 +397,7 @@ func (a *Driver) applyDiff(id string, diff archive.Reader) error {
 // DiffSize calculates the changes between the specified id
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (a *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (a *Driver) DiffSize(id, parent, mountlabel string) (size int64, err error) {
 	// AUFS doesn't need the parent layer to calculate the diff size.
 	return directory.Size(path.Join(a.rootPath(), "diff", id))
 }
@@ -405,18 +405,18 @@ func (a *Driver) DiffSize(id, parent string) (size int64, err error) {
 // ApplyDiff extracts the changeset from the given diff into the
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
-func (a *Driver) ApplyDiff(id, parent string, diff archive.Reader) (size int64, err error) {
+func (a *Driver) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error) {
 	// AUFS doesn't need the parent id to apply the diff.
 	if err = a.applyDiff(id, diff); err != nil {
 		return
 	}
 
-	return a.DiffSize(id, parent)
+	return a.DiffSize(id, parent, mountlabel)
 }
 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
-func (a *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (a *Driver) Changes(id, parent, mountlabel string) ([]archive.Change, error) {
 	// AUFS doesn't have snapshots, so we need to get changes from all parent
 	// layers.
 	layers, err := a.getParentLayerPaths(id)

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -341,7 +341,7 @@ func TestGetDiff(t *testing.T) {
 	}
 	f.Close()
 
-	a, err := d.Diff("1", "")
+	a, err := d.Diff("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -385,7 +385,7 @@ func TestChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err := d.Changes("2", "")
+	changes, err := d.Changes("2", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +424,7 @@ func TestChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err = d.Changes("3", "")
+	changes, err = d.Changes("3", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func TestDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err := d.DiffSize("1", "")
+	diffSize, err := d.DiffSize("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +518,7 @@ func TestChildDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err := d.DiffSize("1", "")
+	diffSize, err := d.DiffSize("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -530,7 +530,7 @@ func TestChildDiffSize(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffSize, err = d.DiffSize("2", "")
+	diffSize, err = d.DiffSize("2", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -613,7 +613,7 @@ func TestApplyDiff(t *testing.T) {
 	}
 	f.Close()
 
-	diff, err := d.Diff("1", "")
+	diff, err := d.Diff("1", "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -625,7 +625,7 @@ func TestApplyDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := d.applyDiff("3", diff); err != nil {
+	if err := d.applyDiff("3", diff, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -81,19 +81,19 @@ type Driver interface {
 	ProtoDriver
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
-	Diff(id, parent string) (archive.Archive, error)
+	Diff(id, parent, mountlabel string) (archive.Archive, error)
 	// Changes produces a list of changes between the specified layer
 	// and its parent layer. If parent is "", then all changes will be ADD changes.
-	Changes(id, parent string) ([]archive.Change, error)
+	Changes(id, parent, mountlabel string) ([]archive.Change, error)
 	// ApplyDiff extracts the changeset from the given diff into the
 	// layer with the specified id and parent, returning the size of the
 	// new layer in bytes.
 	// The archive.Reader must be an uncompressed stream.
-	ApplyDiff(id, parent string, diff archive.Reader) (size int64, err error)
+	ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error)
 	// DiffSize calculates the changes between the specified id
 	// and its parent and returns the size in bytes of the changes
 	// relative to its base filesystem directory.
-	DiffSize(id, parent string) (size int64, err error)
+	DiffSize(id, parent, mountlabel string) (size int64, err error)
 }
 
 // DiffGetterDriver is the interface for layered file system drivers that

--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -31,10 +31,10 @@ type NaiveDiffDriver struct {
 // NewNaiveDiffDriver returns a fully functional driver that wraps the
 // given ProtoDriver and adds the capability of the following methods which
 // it may or may not support on its own:
-//     Diff(id, parent string) (archive.Archive, error)
-//     Changes(id, parent string) ([]archive.Change, error)
-//     ApplyDiff(id, parent string, diff archive.Reader) (size int64, err error)
-//     DiffSize(id, parent string) (size int64, err error)
+//     Diff(id, parent, mountlabel string) (archive.Archive, error)
+//     Changes(id, parent, mountlabel string) ([]archive.Change, error)
+//     ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error)
+//     DiffSize(id, parent, mountlabel string) (size int64, err error)
 func NewNaiveDiffDriver(driver ProtoDriver, uidMaps, gidMaps []idtools.IDMap) Driver {
 	return &NaiveDiffDriver{ProtoDriver: driver,
 		uidMaps: uidMaps,
@@ -43,10 +43,10 @@ func NewNaiveDiffDriver(driver ProtoDriver, uidMaps, gidMaps []idtools.IDMap) Dr
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err error) {
+func (gdw *NaiveDiffDriver) Diff(id, parent, mountlabel string) (arch archive.Archive, err error) {
 	driver := gdw.ProtoDriver
 
-	layerFs, err := driver.Get(id, "")
+	layerFs, err := driver.Get(id, mountlabel)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err e
 		}), nil
 	}
 
-	parentFs, err := driver.Get(parent, "")
+	parentFs, err := driver.Get(parent, mountlabel)
 	if err != nil {
 		return nil, err
 	}
@@ -94,10 +94,10 @@ func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err e
 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
-func (gdw *NaiveDiffDriver) Changes(id, parent string) ([]archive.Change, error) {
+func (gdw *NaiveDiffDriver) Changes(id, parent, mountlabel string) ([]archive.Change, error) {
 	driver := gdw.ProtoDriver
 
-	layerFs, err := driver.Get(id, "")
+	layerFs, err := driver.Get(id, mountlabel)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (gdw *NaiveDiffDriver) Changes(id, parent string) ([]archive.Change, error)
 	parentFs := ""
 
 	if parent != "" {
-		parentFs, err = driver.Get(parent, "")
+		parentFs, err = driver.Get(parent, mountlabel)
 		if err != nil {
 			return nil, err
 		}
@@ -119,11 +119,11 @@ func (gdw *NaiveDiffDriver) Changes(id, parent string) ([]archive.Change, error)
 // ApplyDiff extracts the changeset from the given diff into the
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
-func (gdw *NaiveDiffDriver) ApplyDiff(id, parent string, diff archive.Reader) (size int64, err error) {
+func (gdw *NaiveDiffDriver) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error) {
 	driver := gdw.ProtoDriver
 
 	// Mount the root filesystem so we can apply the diff/layer.
-	layerFs, err := driver.Get(id, "")
+	layerFs, err := driver.Get(id, mountlabel)
 	if err != nil {
 		return
 	}
@@ -144,15 +144,15 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id, parent string, diff archive.Reader) (s
 // DiffSize calculates the changes between the specified layer
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (gdw *NaiveDiffDriver) DiffSize(id, parent string) (size int64, err error) {
+func (gdw *NaiveDiffDriver) DiffSize(id, parent, mountlabel string) (size int64, err error) {
 	driver := gdw.ProtoDriver
 
-	changes, err := gdw.Changes(id, parent)
+	changes, err := gdw.Changes(id, parent, mountlabel)
 	if err != nil {
 		return
 	}
 
-	layerFs, err := driver.Get(id, "")
+	layerFs, err := driver.Get(id, mountlabel)
 	if err != nil {
 		return
 	}

--- a/daemon/graphdriver/graphtest/graphbench_unix.go
+++ b/daemon/graphdriver/graphtest/graphbench_unix.go
@@ -144,7 +144,7 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 	if err := addManyFiles(driver, upper, fileCount, 6); err != nil {
 		b.Fatal(err)
 	}
-	diffSize, err := driver.DiffSize(upper, "")
+	diffSize, err := driver.DiffSize(upper, "", "")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -162,12 +162,12 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 
 		b.StartTimer()
 
-		arch, err := driver.Diff(upper, "")
+		arch, err := driver.Diff(upper, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}
 
-		applyDiffSize, err := driver.ApplyDiff(diff, "", arch)
+		applyDiffSize, err := driver.ApplyDiff(diff, "", "", arch)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -207,7 +207,7 @@ func DriverBenchDeepLayerDiff(b *testing.B, layerCount int, drivername string, d
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		arch, err := driver.Diff(topLayer, "")
+		arch, err := driver.Diff(topLayer, "", "")
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/daemon/graphdriver/graphtest/graphtest_unix.go
+++ b/daemon/graphdriver/graphtest/graphtest_unix.go
@@ -224,7 +224,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	diffSize, err := driver.DiffSize(upper, "")
+	diffSize, err := driver.DiffSize(upper, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	applyDiffSize, err := driver.ApplyDiff(diff, base, bytes.NewReader(buf.Bytes()))
+	applyDiffSize, err := driver.ApplyDiff(diff, base, "", bytes.NewReader(buf.Bytes()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -297,7 +297,7 @@ func DriverTestChanges(t testing.TB, drivername string, driverOptions ...string)
 		t.Fatal(err)
 	}
 
-	changes, err := driver.Changes(upper, base)
+	changes, err := driver.Changes(upper, base, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -35,7 +35,7 @@ type ApplyDiffProtoDriver interface {
 	graphdriver.ProtoDriver
 	// ApplyDiff writes the diff to the archive for the given id and parent id.
 	// It returns the size in bytes written if successful, an error ErrApplyDiffFallback is returned otherwise.
-	ApplyDiff(id, parent string, diff archive.Reader) (size int64, err error)
+	ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error)
 }
 
 type naiveDiffDriverWithApply struct {
@@ -52,10 +52,10 @@ func NaiveDiffDriverWithApply(driver ApplyDiffProtoDriver, uidMaps, gidMaps []id
 }
 
 // ApplyDiff creates a diff layer with either the NaiveDiffDriver or with a fallback.
-func (d *naiveDiffDriverWithApply) ApplyDiff(id, parent string, diff archive.Reader) (int64, error) {
-	b, err := d.applyDiff.ApplyDiff(id, parent, diff)
+func (d *naiveDiffDriverWithApply) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (int64, error) {
+	b, err := d.applyDiff.ApplyDiff(id, parent, mountlabel, diff)
 	if err == ErrApplyDiffFallback {
-		return d.Driver.ApplyDiff(id, parent, diff)
+		return d.Driver.ApplyDiff(id, parent, mountlabel, diff)
 	}
 	return b, err
 }
@@ -386,7 +386,7 @@ func (d *Driver) Put(id string) error {
 }
 
 // ApplyDiff applies the new layer on top of the root, if parent does not exist with will return an ErrApplyDiffFallback error.
-func (d *Driver) ApplyDiff(id string, parent string, diff archive.Reader) (size int64, err error) {
+func (d *Driver) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error) {
 	dir := d.dir(id)
 
 	if parent == "" {

--- a/daemon/graphdriver/overlay/overlay_test.go
+++ b/daemon/graphdriver/overlay/overlay_test.go
@@ -47,7 +47,7 @@ func TestOverlayDiffApply10Files(t *testing.T) {
 
 func TestOverlayChanges(t *testing.T) {
 	t.Skipf("Fails to compute changes intermittently")
-	graphtest.DriverTestChanges(t, "overlay")
+	graphtest.DriverTestChanges(t, "overlay", "")
 }
 
 func TestOverlayTeardown(t *testing.T) {

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -452,7 +452,7 @@ func (d *Driver) Exists(id string) bool {
 }
 
 // ApplyDiff applies the new layer into a root
-func (d *Driver) ApplyDiff(id string, parent string, diff archive.Reader) (size int64, err error) {
+func (d *Driver) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (size int64, err error) {
 	applyDir := d.getDiffPath(id)
 
 	logrus.Debugf("Applying tar in %s", applyDir)
@@ -465,7 +465,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff archive.Reader) (size 
 		return 0, err
 	}
 
-	return d.DiffSize(id, parent)
+	return d.DiffSize(id, parent, mountlabel)
 }
 
 func (d *Driver) getDiffPath(id string) string {
@@ -477,13 +477,13 @@ func (d *Driver) getDiffPath(id string) string {
 // DiffSize calculates the changes between the specified id
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (d *Driver) DiffSize(id, parent, mountlabel string) (size int64, err error) {
 	return directory.Size(d.getDiffPath(id))
 }
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (d *Driver) Diff(id, parent string) (archive.Archive, error) {
+func (d *Driver) Diff(id, parent, mountlabel string) (archive.Archive, error) {
 	diffPath := d.getDiffPath(id)
 	logrus.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{
@@ -496,7 +496,7 @@ func (d *Driver) Diff(id, parent string) (archive.Archive, error) {
 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
-func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (d *Driver) Changes(id, parent, mountlabel string) ([]archive.Change, error) {
 	// Overlay doesn't have snapshots, so we need to get changes from all parent
 	// layers.
 	diffPath := d.getDiffPath(id)

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -170,10 +170,11 @@ func (d *graphDriverProxy) Cleanup() error {
 	return nil
 }
 
-func (d *graphDriverProxy) Diff(id, parent string) (archive.Archive, error) {
+func (d *graphDriverProxy) Diff(id, parent, mountlabel string) (archive.Archive, error) {
 	args := &graphDriverRequest{
-		ID:     id,
-		Parent: parent,
+		ID:         id,
+		Parent:     parent,
+		MountLabel: mountlabel,
 	}
 	body, err := d.client.Stream("GraphDriver.Diff", args)
 	if err != nil {
@@ -182,10 +183,11 @@ func (d *graphDriverProxy) Diff(id, parent string) (archive.Archive, error) {
 	return archive.Archive(body), nil
 }
 
-func (d *graphDriverProxy) Changes(id, parent string) ([]archive.Change, error) {
+func (d *graphDriverProxy) Changes(id, parent, mountlabel string) ([]archive.Change, error) {
 	args := &graphDriverRequest{
-		ID:     id,
-		Parent: parent,
+		ID:         id,
+		Parent:     parent,
+		MountLabel: mountlabel,
 	}
 	var ret graphDriverResponse
 	if err := d.client.Call("GraphDriver.Changes", args, &ret); err != nil {
@@ -198,7 +200,7 @@ func (d *graphDriverProxy) Changes(id, parent string) ([]archive.Change, error) 
 	return ret.Changes, nil
 }
 
-func (d *graphDriverProxy) ApplyDiff(id, parent string, diff archive.Reader) (int64, error) {
+func (d *graphDriverProxy) ApplyDiff(id, parent, mountlabel, diff archive.Reader) (int64, error) {
 	var ret graphDriverResponse
 	if err := d.client.SendFile(fmt.Sprintf("GraphDriver.ApplyDiff?id=%s&parent=%s", id, parent), diff, &ret); err != nil {
 		return -1, err
@@ -209,10 +211,11 @@ func (d *graphDriverProxy) ApplyDiff(id, parent string, diff archive.Reader) (in
 	return ret.Size, nil
 }
 
-func (d *graphDriverProxy) DiffSize(id, parent string) (int64, error) {
+func (d *graphDriverProxy) DiffSize(id, parent, mountlabel string) (int64, error) {
 	args := &graphDriverRequest{
-		ID:     id,
-		Parent: parent,
+		ID:         id,
+		Parent:     parent,
+		MountLabel: mountlabel,
 	}
 	var ret graphDriverResponse
 	if err := d.client.Call("GraphDriver.DiffSize", args, &ret); err != nil {

--- a/daemon/graphdriver/windows/windows.go
+++ b/daemon/graphdriver/windows/windows.go
@@ -300,7 +300,7 @@ func (d *Driver) Cleanup() error {
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 // The layer should be mounted when calling this function
-func (d *Driver) Diff(id, parent string) (_ archive.Archive, err error) {
+func (d *Driver) Diff(id, parent, mountlabel string) (_ archive.Archive, err error) {
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return
@@ -336,7 +336,7 @@ func (d *Driver) Diff(id, parent string) (_ archive.Archive, err error) {
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 // The layer should be mounted when calling this function
-func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
+func (d *Driver) Changes(id, parent, mountlabel string) ([]archive.Change, error) {
 	rID, err := d.resolveID(id)
 	if err != nil {
 		return nil, err
@@ -392,7 +392,7 @@ func (d *Driver) Changes(id, parent string) ([]archive.Change, error) {
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
 // The layer should not be mounted when calling this function
-func (d *Driver) ApplyDiff(id, parent string, diff archive.Reader) (int64, error) {
+func (d *Driver) ApplyDiff(id, parent, mountlabel string, diff archive.Reader) (int64, error) {
 	var layerChain []string
 	if parent != "" {
 		rPId, err := d.resolveID(parent)
@@ -426,13 +426,13 @@ func (d *Driver) ApplyDiff(id, parent string, diff archive.Reader) (int64, error
 // DiffSize calculates the changes between the specified layer
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
-func (d *Driver) DiffSize(id, parent string) (size int64, err error) {
+func (d *Driver) DiffSize(id, parent, mountlabel string) (size int64, err error) {
 	rPId, err := d.resolveID(parent)
 	if err != nil {
 		return
 	}
 
-	changes, err := d.Changes(id, rPId)
+	changes, err := d.Changes(id, rPId, mountlabel)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
We should be mounting the images with the mount label when doing a
commit operation.  We have seen a leaked mount point cause the commit
fail on SELinux systems.  If the leaked mount point is a context mount
and the diff tries to mount the image without the context mount, then
the kernel denies the mount.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

