### PR TITLE
journald logs: drain 1 more time at container exit

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -252,6 +252,13 @@ func (s *journald) followJournal(logWatcher *logger.LogWatcher, config logger.Re
 			errstr := C.GoString(cerrstr)
 			fmtstr := "error %q while attempting to follow journal for container %q"
 			logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+		} else {
+			// In the event that we were told to stop (logWatcher.WatchClose() below), it's possible
+			// there's more data in the journal for this container that was written just as the container
+			// exited. Try to drain the journal one more time to pick up any last-minute journal entries.
+			// Note, this isn't fool-proof and there's no guarantee that we'll get all the trailing
+			// entries, but this is better than nothing, as it does yield entries more often than not.
+			s.drainJournal(logWatcher, config, j, cursor)
 		}
 		// Clean up.
 		C.close(pfd[0])


### PR DESCRIPTION
resurrected https://github.com/projectatomic/docker/pull/218 (for master) after @ncdc

I hope it fixes https://github.com/openshift/origin/issues/17747


> In the journald log driver, attempt to drain the journal 1 more time
> after being told to stop following the log. Due to a possible race
> condition, sometimes data is written to the journal at almost the same
> time the log watch is closed, and depending on the order of operations,
> sometimes you miss the last journal entry.
> 
> I'm opening this here for starters so we can discuss. If we decide to proceed with this or something like it, I'll open a pull against docker/docker.
> 
> Fixes issues seen in OpenShift e2e tests such as this: openshift/origin#9839 (comment)

/cc @nalind @runcom @rhatdan @smarterclayton @mrunalp @jwhonce @soltysh @mfojtik @deads2k