### PR TITLE
Initialize Audit loggings cli.daemon

### DIFF
--- a/api/server/middleware/audit_linux.go
+++ b/api/server/middleware/audit_linux.go
@@ -151,11 +151,11 @@ func parseRequest(r *http.Request, d *daemon.Daemon) (string, *container.Contain
 		c, err := d.GetContainer(containerID)
 		if err == nil {
 			if c == nil {
-				logrus.Debug("GetContainer returned nil container.")
+				logrus.Debug("GetContainer returned nil container for ", containerID)
 			}
 			return action, c
 		}
-		logrus.Debug("Unable to determine container.")
+		logrus.Debug("Unable to determine container for ", containerID)
 	}
 	return action, nil
 }
@@ -290,7 +290,9 @@ func logAuditlog(c *container.Container, action string, username string, loginui
 		vmPid = fmt.Sprint(c.State.Pid)
 		exe = c.Path
 		hostname = c.Config.Hostname
-		ctr_id_short = c.ID[0:12]
+		if len(c.ID) > 11 {
+			ctr_id_short = c.ID[0:12]
+		}
 	}
 
 	if username != "" {

--- a/api/server/middleware/audit_linux.go
+++ b/api/server/middleware/audit_linux.go
@@ -150,8 +150,12 @@ func parseRequest(r *http.Request, d *daemon.Daemon) (string, *container.Contain
 	if d != nil {
 		c, err := d.GetContainer(containerID)
 		if err == nil {
+			if c == nil {
+				logrus.Debug("GetContainer returned nil container.")
+			}
 			return action, c
 		}
+		logrus.Debug("Unable to determine container.")
 	}
 	return action, nil
 }
@@ -279,12 +283,14 @@ func logAuditlog(c *container.Container, action string, username string, loginui
 	hostname := "?"
 	user := "?"
 	auid := "?"
+	ctr_id_short := "?"
 
 	if c != nil {
 		vm = c.Config.Image
 		vmPid = fmt.Sprint(c.State.Pid)
 		exe = c.Path
 		hostname = c.Config.Hostname
+		ctr_id_short = c.ID[0:12]
 	}
 
 	if username != "" {
@@ -304,6 +310,7 @@ func logAuditlog(c *container.Container, action string, username string, loginui
 		"auid":     auid,
 		"exe":      exe,
 		"hostname": hostname,
+		"ctr_id_short": ctr_id_short,
 	}
 
 	//Encoding is a function of libaudit that ensures

--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -310,11 +310,11 @@ func (cli *DaemonCli) start() (err error) {
 		"graphdriver": d.GraphDriverName(),
 	}).Info("Docker daemon")
 
-	cli.initMiddlewares(api, serverConfig)
-	initRouter(api, d, c)
-
 	cli.d = d
 	cli.setupConfigReloadTrap()
+
+	cli.initMiddlewares(api, serverConfig)
+	initRouter(api, d, c)
 
 	// The serve API routine never exits unless an error occurs
 	// We need to start it as a goroutine and wait on it so


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Audit logging was not showing the containers id or other information as it should about the container.  The issue was the cli.d field in the dockerd/daemon.code was being passed  down to the cli.initMiddlewares() function before the cli.d field was initialized with the information for the docker daemon.  The cli.initMiddlewares() function initialized the Audit Logging and since it had a nil pointer for the daemon, it was never able to resolve the containers information and the default "?" was always shown instead.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1496176

**- What I did**
I've added a 'ctr_id_short' field to the audit logging and a couple of debug messages.  The fix itself was to move the initialization of the cli.d field above the call to cli.initMiddlewares() within the dockerd/daemon code.

**- How I did it**
Changed the code and lots of testing.

**- How to verify it**

The old audit log entries looked like:
```
type=VIRT_CONTROL msg=audit(1512770060.628:254): pid=1768 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:container_runtime_t:s0 msg='op=attach vm-pid=? auid=0 hostname=? reason=api vm=? user=root exe=?  exe="/usr/bin/dockerd-current" hostname=? addr=? terminal=? res=success' 
```
The new ones look like:
```
type=VIRT_CONTROL msg=audit(1515610710.130:485): pid=19793 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:container_runtime_t:s0 msg='reason=api auid=0 exe=sleep hostname=8386cb7735f4 ctr_id_short=8386cb7735f4 op=attach vm=centos vm-pid=0 user=root  exe="/usr/bin/dockerd-current" hostname=? addr=? terminal=? res=success' 
```
Note the addition of the ctr_id_short field and the appropriate values in the vm, vm-pid, exed and other fields.

**- Description for the changelog**
Correct audit logging for container operations.
