### PR TITLE
Add ctr_id_short to Audit log

### DIFF
--- a/api/server/middleware/audit_linux.go
+++ b/api/server/middleware/audit_linux.go
@@ -159,8 +159,12 @@ func parseRequest(r *http.Request, d *daemon.Daemon) (string, *container.Contain
 	if d != nil {
 		c, err := d.GetContainer(containerID)
 		if err == nil {
+			if c == nil {
+				logrus.Debug("GetContainer returned nil container for ", containerID)
+			}
 			return action, c
 		}
+		logrus.Debug("Unable to determine container for ", containerID)
 	}
 	return action, nil
 }
@@ -288,12 +292,16 @@ func logAuditlog(c *container.Container, action string, username string, loginui
 	hostname := "?"
 	user := "?"
 	auid := "?"
+	ctr_id_short := "?"
 
 	if c != nil {
 		vm = c.Config.Image
 		vmPid = fmt.Sprint(c.State.Pid)
 		exe = c.Path
 		hostname = c.Config.Hostname
+		if len(c.ID) > 11 {
+			ctr_id_short = c.ID[0:12]
+		}
 	}
 
 	if username != "" {
@@ -313,6 +321,7 @@ func logAuditlog(c *container.Container, action string, username string, loginui
 		"auid":     auid,
 		"exe":      exe,
 		"hostname": hostname,
+		"ctr_id_short": ctr_id_short,
 	}
 
 	//Encoding is a function of libaudit that ensures


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
Audit logging was not showing the containers id.  Unlike docker-1.12.6, the audit middleware is being initialized appropriately in this version and dockerd/daemon.go did not need to be fixed.  This change only adds the short container id to the audit log.

This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1496176

- What I did
I've added a 'ctr_id_short' field to the audit logging and a couple of debug messages.

- How I did it
Changed the code and lots of testing.

- How to verify it

The old audit log entries looked like:

type=VIRT_CONTROL msg=audit(1512770060.628:254): pid=1768 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:container_runtime_t:s0 msg='op=attach vm-pid=? auid=0 hostname=? reason=api vm=? user=root exe=?  exe="/usr/bin/dockerd-current" hostname=? addr=? terminal=? res=success' 

The new ones look like:

type=VIRT_CONTROL msg=audit(1515610710.130:485): pid=19793 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:container_runtime_t:s0 msg='reason=api auid=0 exe=sleep hostname=8386cb7735f4 ctr_id_short=8386cb7735f4 op=attach vm=centos vm-pid=0 user=root  exe="/usr/bin/dockerd-current" hostname=? addr=? terminal=? res=success' 

Note the addition of the ctr_id_short field and the appropriate values in the vm, vm-pid, exed and other fields.

- Description for the changelog
Correct audit logging for container operations.
