### PR TITLE
Adjust Audit init in 1.12.6 to match 1.13.1

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -311,10 +311,12 @@ func (cli *DaemonCli) start() (err error) {
 	}).Info("Docker daemon")
 
 	cli.d = d
-	cli.setupConfigReloadTrap()
 
+	// initMiddlewares needs cli.d to be populated. Dont change this init order.
 	cli.initMiddlewares(api, serverConfig)
 	initRouter(api, d, c)
+
+	cli.setupConfigReloadTrap()
 
 	// The serve API routine never exits unless an error occurs
 	// We need to start it as a goroutine and wait on it so


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
**- What I did**

While working on #293 I noted that the dockerd/daemon.go code in 1-13.1-rhel initialized the audit logging code in a similar manner to my fix in #292.  This change brings the code in 1-12.6 in line with 1-13.1 which primarily adds a warning in  a comment about the order of initialization for audit log.

**- How I did it**
vi is my friend, and lots of testing.

**- How to verify it**
There should be no discernible run time changes, the code works the same, it's just a little better ordered and commented in the code for future code maintenance.

**- Description for the changelog**
Adjust internal ordering of audit logging.

This is part of the series of fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1496176

