### PR TITLE
Attempt to avoid leaking or holding open descriptors for deleted journal files

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -223,7 +223,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
 				// Attempt to rewind the last-read cursor to the
 				// entry that we last sent.
-				C.sd_journal_previous(j)
+				if status = C.sd_journal_previous(j); status < 0 {
+					cerrstr := C.strerror(C.int(-status))
+					errstr := C.GoString(cerrstr)
+					fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+					logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				}
 				break
 			}
 		}
@@ -233,7 +238,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
 			// Attempt to rewind the last-read cursor to the entry
 			// that we last sent.
-			C.sd_journal_previous(j)
+			if status := C.sd_journal_previous(j); status < 0 {
+				cerrstr := C.strerror(C.int(-status))
+				errstr := C.GoString(cerrstr)
+				fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+			}
 			break
 		}
 		// Read and send the current message, if there is one to read.
@@ -244,7 +254,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 				// Attempt to rewind the last-read
 				// cursor to the entry that we last
 				// sent.
-				C.sd_journal_previous(j)
+				if status := C.sd_journal_previous(j); status < 0 {
+					cerrstr := C.strerror(C.int(-status))
+					errstr := C.GoString(cerrstr)
+					fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+					logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				}
 				break
 			}
 			// Set up the time and text of the entry.

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -228,7 +228,7 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 			}
 		}
 		// If the output channel is full, stop here, so that we don't block indefinitely
-		// waiting until we can output another message, when won't ever happen if the
+		// waiting until we can output another message, which won't ever happen if the
 		// client has already disconnected.
 		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
 			// Attempt to rewind the last-read cursor to the entry

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -175,11 +175,27 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 
 	// Walk the journal from here forward until we run out of new entries.
 drain:
-	for {
+	for processed := uint64(0); ; processed++ {
 		// If the output channel is full, stop here, so that we don't block indefinitely
 		// when we get to the point where we can output the message.
 		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
 			break
+		}
+		// If we're not keeping up with journald writing to the journal, some of the
+		// files between where we are and "now" may have been deleted since we started
+		// walking the set of entries.  If that's happened, the inotify descriptor in
+		// the journal handle will have pending deletion events.  Letting the journal
+		// library process them will close any that are already deleted, so that we'll
+		// skip over them and allow space that would have been reclaimed by deleting
+		// these files to actually be reclaimed.
+		if processed%1024 == 0 {
+			if status := C.sd_journal_process(j); status < 0 {
+				cerrstr := C.strerror(C.int(-status))
+				errstr := C.GoString(cerrstr)
+				fmtstr := "error %q while attempting to process journal events for container %q"
+				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				break
+			}
 		}
 		// Try not to send a given entry twice.
 		if oldCursor != "" {

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -138,7 +138,9 @@ package journald
 //			/* The close notification pipe was closed. */
 //			return 0;
 //		}
-//		if (sd_journal_process(j) == SD_JOURNAL_APPEND) {
+//		switch (sd_journal_process(j)) {
+//		case SD_JOURNAL_APPEND:
+//		case SD_JOURNAL_INVALIDATE:
 //			/* Data, which we might care about, was appended. */
 //			return 1;
 //		}

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -309,6 +309,19 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 		close(logWatcher.Msg)
 		return
 	}
+	// The journal library uses an inotify descriptor to notice when
+	// journal files are removed, but it isn't allocated until our first
+	// call to sd_journal_get_fd(), which means that it will not notice the
+	// removal of any files that happens after we open the journal and
+	// before the first time we try to read that descriptor.  Do it now,
+	// even though we don't need its value just yet, to try to make that
+	// window smaller.
+	rc = C.sd_journal_get_fd(j)
+	if rc < 0 {
+		logWatcher.Err <- fmt.Errorf("error opening journal inotify descriptor")
+		close(logWatcher.Msg)
+		return
+	}
 	// If we end up following the log, we can set the journal context
 	// pointer and the channel pointer to nil so that we won't close them
 	// here, potentially while the goroutine that uses them is still

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -176,6 +176,11 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 	// Walk the journal from here forward until we run out of new entries.
 drain:
 	for {
+		// If the output channel is full, stop here, so that we don't block indefinitely
+		// when we get to the point where we can output the message.
+		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
+			break
+		}
 		// Try not to send a given entry twice.
 		if oldCursor != "" {
 			ccursor := C.CString(oldCursor)
@@ -287,10 +292,16 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	var j *C.sd_journal
 	var cmatch *C.char
 	var stamp C.uint64_t
+	var initiated C.uint64_t = 0xffffffffffffffff
 	var sinceUnixMicro uint64
 	var pipes [2]C.int
+	var ts C.struct_timespec
 	cursor := ""
 
+	// Get the current time, so that we know when to stop in non-follow mode.
+	if C.clock_gettime(C.CLOCK_REALTIME, &ts) == 0 {
+		initiated = C.uint64_t(ts.tv_sec)*1000000000 + C.uint64_t(ts.tv_nsec)
+	}
 	// Get a handle to the journal.
 	rc := C.sd_journal_open(&j, C.int(0))
 	if rc != 0 {
@@ -395,6 +406,30 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 				following = true
 			}
 		}
+	} else {
+		// In case we stopped reading because the output channel was
+		// temporarily full, keep going until we cross the point where
+		// the timestamps on entries are later than when we started
+		// reading the log, to avoid trying to keep going until we
+		// hit the end of the journal when we just can't keep up.
+		duration := 10 * time.Millisecond
+		timer := time.NewTimer(duration)
+	drainCatchup:
+		for stamp < initiated {
+			timer.Stop()
+			cursor = s.drainJournal(logWatcher, config, j, cursor)
+			if C.sd_journal_get_realtime_usec(j, &stamp) != 0 {
+				break drainCatchup
+			}
+			timer.Reset(duration)
+			select {
+			case <-logWatcher.WatchClose():
+				break drainCatchup
+			case <-timer.C:
+				break drainCatchup
+			}
+		}
+		timer.Stop()
 	}
 	return
 }

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -345,12 +345,12 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	// here, potentially while the goroutine that uses them is still
 	// running.  Otherwise, close them when we return from this function.
 	following := false
-	defer func(pfollowing *bool) {
-		if !*pfollowing {
+	defer func() {
+		if !following {
 			C.sd_journal_close(j)
 			close(logWatcher.Msg)
 		}
-	}(&following)
+	}()
 	// Remove limits on the size of data items that we'll retrieve.
 	rc = C.sd_journal_set_data_threshold(j, C.size_t(0))
 	if rc != 0 {

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -175,45 +175,75 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 	var stamp C.uint64_t
 	var priority, partial C.int
 
-	// Walk the journal from here forward until we run out of new entries.
-drain:
-	for processed := uint64(0); ; processed++ {
-		// If the output channel is full, stop here, so that we don't block indefinitely
-		// when we get to the point where we can output the message.
-		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
-			break
+	// Give the journal handle an opportunity to close any open descriptors
+	// for files that have been removed.
+	C.sd_journal_process(j)
+
+	// Seek to the location of the last entry that we sent.
+	if oldCursor != "" {
+		startCursor := C.CString(oldCursor)
+		defer C.free(unsafe.Pointer(startCursor))
+		// We know which entry was read last, so try to go to that
+		// location.
+		rc := C.sd_journal_seek_cursor(j, startCursor)
+		if rc != 0 {
+			return oldCursor
 		}
+		// Go forward to the first unsent message.
+		rc = C.sd_journal_next(j)
+		if rc < 0 {
+			return oldCursor
+		}
+		// We want to avoid sending a given entry twice (or more), so
+		// attempt to advance to the first unread entry in the journal
+		// so long as "this" one matches the last entry that we read.
+		for C.sd_journal_test_cursor(j, startCursor) > 0 {
+			if C.sd_journal_next(j) <= 0 {
+				return oldCursor
+			}
+		}
+	}
+
+	// Walk the journal from here forward until we run out of new entries.
+	var sent uint64
+	for {
 		// If we're not keeping up with journald writing to the journal, some of the
 		// files between where we are and "now" may have been deleted since we started
 		// walking the set of entries.  If that's happened, the inotify descriptor in
-		// the journal handle will have pending deletion events.  Letting the journal
-		// library process them will close any that are already deleted, so that we'll
-		// skip over them and allow space that would have been reclaimed by deleting
-		// these files to actually be reclaimed.
-		if processed%1024 == 0 {
+		// the journal handle will have pending deletion events after we've been reading
+		// for a while.  Letting the journal library process them will close any that
+		// are already deleted, so that we'll skip over them and allow space that would
+		// have been reclaimed by deleting these files to actually be reclaimed.
+		if sent > 0 && sent%1024 == 0 {
 			if status := C.sd_journal_process(j); status < 0 {
 				cerrstr := C.strerror(C.int(-status))
 				errstr := C.GoString(cerrstr)
 				fmtstr := "error %q while attempting to process journal events for container %q"
 				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				// Attempt to rewind the last-read cursor to the
+				// entry that we last sent.
+				C.sd_journal_previous(j)
 				break
 			}
 		}
-		// Try not to send a given entry twice.
-		if oldCursor != "" {
-			ccursor := C.CString(oldCursor)
-			defer C.free(unsafe.Pointer(ccursor))
-			for C.sd_journal_test_cursor(j, ccursor) > 0 {
-				if C.sd_journal_next(j) <= 0 {
-					break drain
-				}
-			}
+		// If the output channel is full, stop here, so that we don't block indefinitely
+		// waiting until we can output another message, when won't ever happen if the
+		// client has already disconnected.
+		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
+			// Attempt to rewind the last-read cursor to the entry
+			// that we last sent.
+			C.sd_journal_previous(j)
+			break
 		}
-		// Read and send the logged message, if there is one to read.
+		// Read and send the current message, if there is one to read.
 		i := C.get_message(j, &msg, &length, &partial)
 		if i != -C.ENOENT && i != -C.EADDRNOTAVAIL {
 			// Read the entry's timestamp.
 			if C.sd_journal_get_realtime_usec(j, &stamp) != 0 {
+				// Attempt to rewind the last-read
+				// cursor to the entry that we last
+				// sent.
+				C.sd_journal_previous(j)
 				break
 			}
 			// Set up the time and text of the entry.
@@ -252,11 +282,17 @@ drain:
 				Attrs:     attrs,
 			}
 		}
-		// If we're at the end of the journal, we're done (for now).
+		// If we've hit the end of the journal, we're done (for now).
+		sent++
 		if C.sd_journal_next(j) <= 0 {
 			break
 		}
 	}
+	// If we didn't send any entries, just return the same cursor value.
+	if oldCursor != "" && sent == 0 {
+		return oldCursor
+	}
+	// Take note of which entry we most recently sent.
 	retCursor := ""
 	if C.sd_journal_get_cursor(j, &cursor) == 0 {
 		retCursor = C.GoString(cursor)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/moby/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
This is taking a stab at fixing the open-file-handles-for-deleted-journal-files bug at https://bugzilla.redhat.com/show_bug.cgi?id=1534827.

**- How I did it**
We weren't handling SD_JOURNAL_INVALIDATE results coming back from sd_journal_process() before, so I added logic to close and reopen the journal handle when we get that result.

**- How to verify it**
Run `docker logs -f` to tail the journaled output from a container that was started with `--log-driver journald`, and consult the list of open descriptors in the directory under `/proc/PID/fd` which corresponds to the docker process to see which journal files it has open.
While `docker logs -f` is running, use `journalctl --vacuum-size` or `journalctl --vacuum-files` to force the removal of one or more older journal files which `dockerd` had open, then consult its `fd` directory again: it should no longer have open descriptors for files which were removed (i.e., the kernel should not be noting any journal files which it has open as `(deleted)`).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
When following a journal in the journald log reader, correctly handle SD_JOURNAL_INVALIDATE results from `sd_journal_process()` by closing and reopening the journal handle, which closes all open journal files (including deleted ones) and opening all currently-available journal files.