### PR TITLE
Try to avoid getting stuck when draining the journal

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -223,7 +223,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
 				// Attempt to rewind the last-read cursor to the
 				// entry that we last sent.
-				C.sd_journal_previous(j)
+				if status = C.sd_journal_previous(j); status < 0 {
+					cerrstr := C.strerror(C.int(-status))
+					errstr := C.GoString(cerrstr)
+					fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+					logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				}
 				break
 			}
 		}
@@ -233,7 +238,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
 			// Attempt to rewind the last-read cursor to the entry
 			// that we last sent.
-			C.sd_journal_previous(j)
+			if status := C.sd_journal_previous(j); status < 0 {
+				cerrstr := C.strerror(C.int(-status))
+				errstr := C.GoString(cerrstr)
+				fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+				logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+			}
 			break
 		}
 		// Read and send the current message, if there is one to read.
@@ -244,7 +254,12 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 				// Attempt to rewind the last-read
 				// cursor to the entry that we last
 				// sent.
-				C.sd_journal_previous(j)
+				if status := C.sd_journal_previous(j); status < 0 {
+					cerrstr := C.strerror(C.int(-status))
+					errstr := C.GoString(cerrstr)
+					fmtstr := "error %q while attempting to rewind journal by 1 for container %q"
+					logrus.Errorf(fmtstr, errstr, s.vars["CONTAINER_ID_FULL"])
+				}
 				break
 			}
 			// Set up the time and text of the entry.

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -353,12 +353,12 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	// here, potentially while the goroutine that uses them is still
 	// running.  Otherwise, close them when we return from this function.
 	following := false
-	defer func(pfollowing *bool) {
-		if !*pfollowing {
+	defer func() {
+		if !following {
 			close(logWatcher.Msg)
 		}
 		C.sd_journal_close(j)
-	}(&following)
+	}()
 	// Remove limits on the size of data items that we'll retrieve.
 	rc = C.sd_journal_set_data_threshold(j, C.size_t(0))
 	if rc != 0 {

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -140,7 +140,9 @@ package journald
 //			/* The close notification pipe was closed. */
 //			return 0;
 //		}
-//		if (sd_journal_process(j) == SD_JOURNAL_APPEND) {
+//		switch (sd_journal_process(j)) {
+//		case SD_JOURNAL_APPEND:
+//		case SD_JOURNAL_INVALIDATE:
 //			/* Data, which we might care about, was appended. */
 //			return 1;
 //		}

--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -228,7 +228,7 @@ func (s *journald) drainJournal(logWatcher *logger.LogWatcher, config logger.Rea
 			}
 		}
 		// If the output channel is full, stop here, so that we don't block indefinitely
-		// waiting until we can output another message, when won't ever happen if the
+		// waiting until we can output another message, which won't ever happen if the
 		// client has already disconnected.
 		if len(logWatcher.Msg) >= cap(logWatcher.Msg) {
 			// Attempt to rewind the last-read cursor to the entry


### PR DESCRIPTION
**- What I did**

Try to fix dockerd-keeps-deleted-journal-files-open-forever problems by keeping the reading goroutine from blocking indefinitely.

**- How I did it**

When draining the journal, if the output message channel is full, stop reading, at least for now.  This keeps us from blocking indefinitely when a client hangs up on us and the channel is full.  Doing this requires that we make multiple calls to `drainJournal()`, even in non-follow mode.

In non-follow mode, keep trying to read until we run out of entries or hit the "until" cutoff, which if not specified, we set to "now".  If we don't do that, and we start reading but can't keep up with the journal,
we'll never catch up even after we get to journal messages which were logged long after we started looking for the then-present logs.

The journal API opens the journal files when the journal handle is opened by `sd_journal_open()`, and uses an inotify descriptor to notice when files have been added or removed, but it doesn't set up that
inotify descriptor until the first time that `sd_journal_get_fd()` is called (either by a client, or as part of `sd_journal_wait()`).  We hadn't been doing that until our initial read-through of entries was done,
meaning that we've been missing file deletion events that occurred during our first pass at reading the journal.  Make that window shorter.

Periodically call `sd_journal_process()` when reading the journal, to let it skip over and close handles to journal files which have been deleted since we started reading the journal, for cases where our keeping them open contributes to a shortage of disk space.

Treat `SD_JOURNAL_INVALIDATE` like `SD_JOURNAL_APPEND`, since `sd_journal_process()` prefers to return INVALIDATE over APPEND when both are applicable.

Clean up a deferred function call in the journal reading logic.

**- How to verify it**

One way to force a reasonably high turnover rate in the journal is to set `RateLimitBurst=0` and `SystemMaxFileSize=10M` in `/etc/systemd/journald.conf`, and use the `busybox` image running `seq` with a large number (say, a million or ten million) as its argument.

Running `docker logs -f` should follow the container's output until the container exits or the daemon closes the logging handle internally.  `docker logs` should follow along until the container exits or it hits the end of the log.  After the container exits, either command should run to completion and not hang.  If either command is paused at the client (using ctrl-s, waiting several seconds, then ctrl-q to unpause) while running, possibly with an intervening `journalctl --vacuum-size1` pruning down the size of the journal, despite any gaps in the output, the ordering between messages received by the client should be preserved.  If instead of unpausing the client, the client is stopped with ctrl-c, open descriptors that dockerd was using for reading the journal should be closed.

At pretty much any time, we shouldn't be holding open descriptors to deleted journal files for more than a fraction of a second.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
journald log reader: avoid blocking indefinitely / holding open deleted files