### PR TITLE
Add better error for subuid/subgid with usernamespace

### DIFF
--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -377,7 +377,9 @@ unix://[/path/to/socket] to use.
   Enable user namespaces for containers on the daemon. Specifying
   a user (or uid) and optionally a group (or gid) will cause the
   daemon to lookup the user and group's subordinate ID ranges for use as the
-  user namespace mappings for contained processes.  These user and groups must
+  user namespace mappings for contained processes. Specifying "default"
+  will cause a "dockremap" user and group to be created if not already present.
+  The "dockremap" user and group, or the specified uid, gid, user or group must
   be created in the subuid(5) and subgid(5) files prior to enablement.
 
 # SIGNATURE VERIFICATION

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -374,13 +374,11 @@ unix://[/path/to/socket] to use.
   Path to the userland proxy binary.
 
 **--userns-remap**=*default*|*uid:gid*|*user:group*|*user*|*uid*
-  Enable user namespaces for containers on the daemon. Specifying "default"
-  will cause a new user and group to be created to handle UID and GID range
-  remapping for the user namespace mappings used for contained processes.
-  Specifying a user (or uid) and optionally a group (or gid) will cause the
+  Enable user namespaces for containers on the daemon. Specifying
+  a user (or uid) and optionally a group (or gid) will cause the
   daemon to lookup the user and group's subordinate ID ranges for use as the
   user namespace mappings for contained processes.  These user and groups must
-  be created in the subuid(5) or subgid(5) files prior to enablement.
+  be created in the subuid(5) and subgid(5) files prior to enablement.
 
 # SIGNATURE VERIFICATION
 

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -379,7 +379,8 @@ unix://[/path/to/socket] to use.
   remapping for the user namespace mappings used for contained processes.
   Specifying a user (or uid) and optionally a group (or gid) will cause the
   daemon to lookup the user and group's subordinate ID ranges for use as the
-  user namespace mappings for contained processes.
+  user namespace mappings for contained processes.  These user and groups must
+  be created in the subuid(5) or subgid(5) files prior to enablement.
 
 # SIGNATURE VERIFICATION
 

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -121,10 +121,10 @@ func CreateIDMappings(username, groupname string) ([]IDMap, []IDMap, error) {
 		return nil, nil, err
 	}
 	if len(subuidRanges) == 0 {
-		return nil, nil, fmt.Errorf("No subuid ranges found for user %q", username)
+		return nil, nil, fmt.Errorf("No subuid ranges found for user %q in %s", username, subuidFileName)
 	}
 	if len(subgidRanges) == 0 {
-		return nil, nil, fmt.Errorf("No subgid ranges found for group %q", groupname)
+		return nil, nil, fmt.Errorf("No subgid ranges found for group %q in %s", groupname, subgidFileName)
 	}
 
 	return createIDMap(subuidRanges), createIDMap(subgidRanges), nil


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**

Updated man page for dockerd to indicate that subuid and subgid files need to be created for --userns-remap and then added a little more verbiage to the errors to make it more user friendly.

**- How I did it**

vi is my friend.

**- How to verify it**
1. Verify that both /etc/subuid and /etc/subgid are present and empty.
2. Add --userns-remap=default to OPTIONS in /etc/sysconfig/docker
3.  restart docker service 'systemctl restart docker'
Should see:
dockerd-current[*]: Can't create ID mappings: No subuid ranges found for user "dockremap" in /etc/subuid

4. enter values into /etc/subuid via 'echo dockremap:808080:1000 >> /etc/subuid'
5. restart docker service 'systemctl restart docker'
Should see: 
dockerd-current[*]: Can't create ID mappings: No subgid ranges found for gid "dockremap" in /etc/subgid

6. enter values into /etc/subgid via 'echo dockremap:808080:1000 >> /etc/subgid'
7. restart docker service 'systemctl restart docker'

Should not see an error.

Verify 'man dockerd' has new verbiage as noted below.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546870

**- Description for the changelog**

Add better error for subuid/subgid with usernamespace


