### PR TITLE
Add better error for subuid/subgid with usernamespace 1.13.1-RHEL

### DIFF
--- a/man/docker-login.1.md
+++ b/man/docker-login.1.md
@@ -14,8 +14,11 @@ docker-login - Log in to a Docker registry.
 # DESCRIPTION
 Log in to a Docker Registry located on the specified
 `SERVER`.  You can specify a URL or a `hostname` for the `SERVER` value. If you
-do not specify a `SERVER`, the command uses Docker's public registry located at
-`https://registry-1.docker.io/` by default.  To get a username/password for Docker's public registry, create an account on Docker Hub.
+do not specify a `SERVER`, the command uses the first value in the field 'registries'
+in the '[registries.search]' table in /etc/containers/registries.conf, and if
+not specified there, Docker's public registry located at `https://registry-1.docker.io/`.
+
+To get a username/password for Docker's public registry, create an account on Docker Hub.
 
 `docker login` requires user to use `sudo` or be `root`, except when:
 
@@ -42,6 +45,10 @@ credentials.  When you log in, the command stores encoded credentials in
 
     # docker login localhost:8080
 
+## Login to Docker Hub overriding /etc/containers/registries.conf
+
+    # docker login docker.io
+
 # See also
 **docker-logout(1)** to log out from a Docker registry.
 
@@ -51,3 +58,4 @@ based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 April 2015, updated by Mary Anthony for v2 <mary@docker.com>
 November 2015, updated by Sally O'Malley <somalley@redhat.com>
+March 2018, updated by Tom Sweeney <tsweeney@redhat.com>

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -1,5 +1,5 @@
 % DOCKER(8) Docker User Manuals
-%  Shishir Mahajan
+% Shishir Mahajan
 % SEPTEMBER 2015
 # NAME
 dockerd - Enable daemon mode

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -1,5 +1,5 @@
 % DOCKER(8) Docker User Manuals
-% Shishir Mahajan
+%  Shishir Mahajan
 % SEPTEMBER 2015
 # NAME
 dockerd - Enable daemon mode

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -374,12 +374,13 @@ unix://[/path/to/socket] to use.
   Path to the userland proxy binary.
 
 **--userns-remap**=*default*|*uid:gid*|*user:group*|*user*|*uid*
-  Enable user namespaces for containers on the daemon. Specifying "default"
-  will cause a new user and group to be created to handle UID and GID range
-  remapping for the user namespace mappings used for contained processes.
-  Specifying a user (or uid) and optionally a group (or gid) will cause the
+  Enable user namespaces for containers on the daemon. Specifying
+  a user (or uid) and optionally a group (or gid) will cause the
   daemon to lookup the user and group's subordinate ID ranges for use as the
-  user namespace mappings for contained processes.
+  user namespace mappings for contained processes. Specifying "default"
+  will cause a "dockremap" user and group to be created if not already present.
+  The "dockremap" user and group, or the specified uid, gid, user or group must
+  be created in the subuid(5) and subgid(5) files prior to enablement.
 
 # SIGNATURE VERIFICATION
 

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -121,10 +121,10 @@ func CreateIDMappings(username, groupname string) ([]IDMap, []IDMap, error) {
 		return nil, nil, err
 	}
 	if len(subuidRanges) == 0 {
-		return nil, nil, fmt.Errorf("No subuid ranges found for user %q", username)
+		return nil, nil, fmt.Errorf("No subuid ranges found for user %q in %s", username, subuidFileName)
 	}
 	if len(subgidRanges) == 0 {
-		return nil, nil, fmt.Errorf("No subgid ranges found for group %q", groupname)
+		return nil, nil, fmt.Errorf("No subgid ranges found for group %q in %s", groupname, subgidFileName)
 	}
 
 	return createIDMap(subuidRanges), createIDMap(subgidRanges), nil


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**

Updated man page for dockerd to indicate that subuid and subgid files need to be created for --userns-remap and then added a little more verbiage to the errors to make it more user friendly.  This is the docker-1.13.1-rhel variant to go along with the docker-1.13.1 variant at #301 

I've added changes to docker login's man page to address https://bugzilla.redhat.com/show_bug.cgi?id=1556956

**- How I did it**

vi is my friend.

**- How to verify it**
1. Verify that both /etc/subuid and /etc/subgid are present and empty.
2. Add --userns-remap=default to OPTIONS in /etc/sysconfig/docker
3.  restart docker service 'systemctl restart docker'
Should see:
dockerd-current[*]: Can't create ID mappings: No subuid ranges found for user "dockremap" in /etc/subuid

4. enter values into /etc/subuid via 'echo dockremap:808080:1000 >> /etc/subuid'
5. restart docker service 'systemctl restart docker'
Should see: 
dockerd-current[*]: Can't create ID mappings: No subgid ranges found for gid "dockremap" in /etc/subgid

6. enter values into /etc/subgid via 'echo dockremap:808080:1000 >> /etc/subgid'
7. restart docker service 'systemctl restart docker'

Should not see an error.

Verify 'man dockerd' has new verbiage as noted below.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1546870

**- Description for the changelog**

Add better error for subuid/subgid with usernamespace
Add information to Docker login man page pertaining to registries


