### PR TITLE
BACKPORT: Serialize non-atomic jump rule programming in bridge

### DIFF
--- a/vendor/github.com/docker/libnetwork/controller.go
+++ b/vendor/github.com/docker/libnetwork/controller.go
@@ -741,7 +741,9 @@ func (c *controller) NewNetwork(networkType, name string, id string, options ...
 
 	joinCluster(network)
 	if !c.isDistributedControl() {
+		c.Lock()
 		arrangeIngressFilterRule()
+		c.Unlock()
 	}
 
 	return network, nil

--- a/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/vendor/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -114,7 +114,10 @@ func (n *bridgeNetwork) setupIPTables(config *networkConfiguration, i *bridgeInt
 		n.portMapper.SetIptablesChain(natChain, n.getNetworkBridgeName())
 	}
 
-	if err := ensureJumpRule("FORWARD", IsolationChain); err != nil {
+	d.Lock()
+	err = ensureJumpRule("FORWARD", IsolationChain)
+	d.Unlock()
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Upstream reference:
https://github.com/docker/libnetwork/pull/1658/commits/fe741120dbacc1c720a80812de1d65811695f5d6

Signed-off-by: Carl George <carl@george.computer>