### PR TITLE
Update docker login manpage regarding registry lookup

### DIFF
--- a/man/docker-login.1.md
+++ b/man/docker-login.1.md
@@ -14,8 +14,11 @@ docker-login - Log in to a Docker registry.
 # DESCRIPTION
 Log in to a Docker Registry located on the specified
 `SERVER`.  You can specify a URL or a `hostname` for the `SERVER` value. If you
-do not specify a `SERVER`, the command uses Docker's public registry located at
-`https://registry-1.docker.io/` by default.  To get a username/password for Docker's public registry, create an account on Docker Hub.
+do not specify a `SERVER`, the command uses the first value in the field 'registries'
+in the '[registries.search]' table in /etc/containers/registries.conf, and if
+not specified there, Docker's public registry located at `https://registry-1.docker.io/`.
+
+To get a username/password for Docker's public registry, create an account on Docker Hub.
 
 `docker login` requires user to use `sudo` or be `root`, except when:
 
@@ -42,6 +45,10 @@ credentials.  When you log in, the command stores encoded credentials in
 
     # docker login localhost:8080
 
+## Login to Docker Hub overriding /etc/containers/registries.conf
+
+    # docker login docker.io
+
 # See also
 **docker-logout(1)** to log out from a Docker registry.
 
@@ -51,3 +58,4 @@ based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 April 2015, updated by Mary Anthony for v2 <mary@docker.com>
 November 2015, updated by Sally O'Malley <somalley@redhat.com>
+March 2018, updated by Tom Sweeney <tsweeney@redhat.com>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Updates the docker-login man page to better explain how registry lookup works.  This addresses https://bugzilla.redhat.com/show_bug.cgi?id=1556956.  This is the second submit for this.  The fix for docker-1.13.1-rhel was completed in #303 

**- What I did**
Updated the docker-login man page.

**- How I did it**
vi is my friend.

**- How to verify it**

After installation, check the docker-login man page for the changes.

**- Description for the changelog**

Clarify how registries are searched for by docker login.

**- A picture of a cute animal (not mandatory but encouraged)**

