### PR TITLE
Remove registry parsing for fully qualified registries

### DIFF
--- a/cli/command/registry.go
+++ b/cli/command/registry.go
@@ -105,10 +105,6 @@ func ConfigureAuth(cli *DockerCli, flUser, flPassword, serverAddress string, isD
 		cli.in = NewInStream(os.Stdin)
 	}
 
-	if !isDefaultRegistry {
-		serverAddress = registry.ConvertToHostname(serverAddress)
-	}
-
 	authconfig, err := cli.CredentialsStore(serverAddress).Get(serverAddress)
 	if err != nil {
 		return authconfig, err


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**
Removed the call to parse the registry from cli/command/registry.go.  This emulates what upstream Docker now does and rather than trying to guess the registry that the user wants, they are responsible for giving us the correct one.  Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1556956  Once OK'd, I'll also add this to docker-1.13.1-RHEL

**- How I did it**
vi is my friend and a bunch of testing.

**- How to verify it**

use `docker login` to log into dockerhub with `docker login docker.io` and `docker login https://index.docker.io/v1/`.  After logging in, the user should be able to pull an image from their private repository.  See test output below.

**- Description for the changelog**
Allow a fully qualified name (https://index.docker.io/v1/) to be used with docker login.


**- Test Output**
```
# cat /etc/containers/registries.conf
# This is a system-wide configuration file used to
# keep track of registries for various container backends.
# It adheres to TOML format and does not support recursive
# lists of registries.

# The default location for this configuration file is /etc/containers/registries.conf.

# The only valid categories are: 'registries.search', 'registries.insecure', 
# and 'registries.block'.

[registries.search]
registries = ['registry.access.redhat.com']

# If you need to access insecure registries, add the registry's fully-qualified name.
# An insecure registry is one that does not have a valid SSL certificate or only does HTTP.
[registries.insecure]
registries = []


# If you need to block pull access from a registry, uncomment the section below
# and add the registries fully-qualified name.
#
# Docker only
[registries.block]
registries = []

################ Tests ##############

# docker login -u tomsweeneyredhat
Password: 
Login Succeeded

# docker pull tomsweeneyredhat/testing:first
Trying to pull repository registry.access.redhat.com/tomsweeneyredhat/testing ... 
Trying to pull repository docker.io/tomsweeneyredhat/testing ... 
repository docker.io/tomsweeneyredhat/testing not found: does not exist or no pull access

# cat ~/.docker/config.json
{
	"auths": {
		"https://registry.access.redhat.com/v1/": {
			"auth": "dG9tc3dlZW5leXJlZGhhdDpaYW1Eb2NrMjAxNyE="
		}
	}
}

# docker login -u tomsweeneyredhat docker.io
Password: 
Login Succeeded

# cat ~/.docker/config.json
{
	"auths": {
		"https://index.docker.io/v1/": {
			"auth": "dG9tc3dlZW5leXJlZGhhdDpaYW1Eb2NrMjAxNyE="
		},
		"https://registry.access.redhat.com/v1/": {
			"auth": "dG9tc3dlZW5leXJlZGhhdDpaYW1Eb2NrMjAxNyE="
		}
	}
}

#docker pull tomsweeneyredhat/testing:first
Trying to pull repository registry.access.redhat.com/tomsweeneyredhat/testing ... 
Trying to pull repository docker.io/tomsweeneyredhat/testing ... 
first: Pulling from docker.io/tomsweeneyredhat/testing
ff3a5c916c92: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:1667286f90c579a6ec0c8428db9f7072289db7fa786cb57f6b9560dde2f64632
Status: Downloaded newer image for docker.io/tomsweeneyredhat/testing:first

# docker rmi $(docker images -q)
Untagged: docker.io/tomsweeneyredhat/testing:first
Untagged: docker.io/tomsweeneyredhat/testing@sha256:1667286f90c579a6ec0c8428db9f7072289db7fa786cb57f6b9560dde2f64632
Deleted: sha256:02b42947bcb6c149171d1808e54071c53915801904baec5be568405559373b03
Deleted: sha256:c332538a772dd349c01ca25f77abff46d6847fcabe79fe0ee31b195a2bace4cd
Deleted: sha256:cd7100a72410606589a54b932cabd804a17f9ae5b42a1882bd56d263e02b6215
Untagged: docker.io/tomsweeneyredhat/blog:whale
Untagged: docker.io/tomsweeneyredhat/blog@sha256:2dcadcd5155ec0f006ec2e84e21b7757a0c31d3c76f814992072a535023f4a76
Deleted: sha256:289a46080c4364857c28464ad503602b52f18a079a8eb73fc2a10793ac9b1786
Deleted: sha256:3dd127c96974c6172e664f3486b69928163c3325dc202b86297c3212de52fb18
Deleted: sha256:34dd66b3cb4467517d0c5c7dbe320b84539fbb58bc21702d2f749a5c932b3a38
Deleted: sha256:52f57e48814ed1bb08a651ef7f91f191db3680212a96b7f318bff0904fed2e65
Deleted: sha256:72915b616c0db6345e52a2c536de38e29208d945889eecef01d0fef0ed207ce8
Deleted: sha256:4ee0c1e90444c9b56880381aff6455f149c92c9a29c3774919632ded4f728d6b
Deleted: sha256:86ac1c0970bf5ea1bf482edb0ba83dbc88fefb1ac431d3020f134691d749d9a6
Deleted: sha256:5c4ac45a28f91f851b66af332a452cba25bd74a811f7e3884ed8723570ad6bc8
Deleted: sha256:088f9eb16f16713e449903f7edb4016084de8234d73a45b1882cf29b1f753a5a
Deleted: sha256:799115b9fdd1511e8af8a8a3c8b450d81aa842bbf3c9f88e9126d264b232c598
Deleted: sha256:3549adbf614379d5c33ef0c5c6486a0d3f577ba3341f573be91b4ba1d8c60ce4
Deleted: sha256:1154ba695078d29ea6c4e1adb55c463959cd77509adf09710e2315827d66271a

# rm ~/.docker/config.json
rm: remove regular file ‘/root/.docker/config.json’? y

#  docker login -u tomsweeneyredhat https://index.docker.io/v1/
Password: 
Login Succeeded

# cat ~/.docker/config.json
{
	"auths": {
		"https://index.docker.io/v1/": {
			"auth": "dG9tc3dlZW5leXJlZGhhdDpaYW1Eb2NrMjAxNyE="
		}
	}
}

#docker pull tomsweeneyredhat/testing:first
Trying to pull repository registry.access.redhat.com/tomsweeneyredhat/testing ... 
Trying to pull repository docker.io/tomsweeneyredhat/testing ... 
first: Pulling from docker.io/tomsweeneyredhat/testing
ff3a5c916c92: Pull complete 
4f4fb700ef54: Pull complete 
Digest: sha256:1667286f90c579a6ec0c8428db9f7072289db7fa786cb57f6b9560dde2f64632
Status: Downloaded newer image for docker.io/tomsweeneyredhat/testing:first

# docker images
REPOSITORY                           TAG                 IMAGE ID            CREATED             SIZE
docker.io/tomsweeneyredhat/testing   first               02b42947bcb6        6 weeks ago         4.15 MB
```
