### PR TITLE
volume: allow a prefix for all bind mounts

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1865,6 +1865,7 @@ _docker_daemon() {
 		--add-runtime
 		--api-cors-header
 		--authorization-plugin
+                --bind-mount-prefix
 		--bip
 		--block-registry
 		--bridge -b

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -38,6 +38,7 @@ type Config struct {
 	SeccompProfile       string                   `json:"seccomp-profile,omitempty"`
 	SigCheck             bool                     `json:"signature-verification"`
 	EnableSecrets        bool                     `json:"enable-secrets"`
+	BindMountPrefix      string                   `json:"bind-mount-prefix"`
 }
 
 // bridgeConfig stores all the bridge driver specific
@@ -93,6 +94,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
 	flags.BoolVar(&config.SigCheck, "signature-verification", true, "Check image's signatures on pull")
 	flags.BoolVar(&config.EnableSecrets, "enable-secrets", true, "Enable Secrets")
+	flags.StringVar(&config.BindMountPrefix, "bind-mount-prefix", "", "Specify a prefix to prepend to the source of a bind mount")
 
 	config.attachExperimentalFlags(flags)
 }

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -43,7 +43,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 			return nil, err
 		}
 		rootUID, rootGID := daemon.GetRemappedUIDGID()
-		path, err := m.Setup(c.MountLabel, rootUID, rootGID)
+		path, err := m.Setup(daemon.configStore.BindMountPrefix, c.MountLabel, rootUID, rootGID)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/reference/commandline/dockerd.md
+++ b/docs/reference/commandline/dockerd.md
@@ -25,6 +25,7 @@ Options:
       --add-runtime value                     Register an additional OCI compatible runtime (default [])
       --api-cors-header string                Set CORS headers in the Engine API
       --authorization-plugin value            Authorization plugins to load (default [])
+      --bind-mount-prefix                     Specify a prefix to prepend to the source of a bind mount
       --bip string                            Specify network bridge IP
   -b, --bridge string                         Attach containers to a network bridge
       --cgroup-parent string                  Set parent cgroup for all containers

--- a/man/dockerd.8.md
+++ b/man/dockerd.8.md
@@ -11,6 +11,7 @@ dockerd - Enable daemon mode
 [**--api-cors-header**=[=*API-CORS-HEADER*]]
 [**--authorization-plugin**[=*[]*]]
 [**-b**|**--bridge**[=*BRIDGE*]]
+[**--bind-mount-prefix[=*PREFIX*]]
 [**--bip**[=*BIP*]]
 [**--block-registry**[=*[]*]]
 [**--cgroup-parent**[=*[]*]]
@@ -132,6 +133,9 @@ $ sudo dockerd --add-runtime runc=runc --add-runtime custom=/usr/local/bin/my-ru
 **-b**, **--bridge**=""
   Attach containers to a pre\-existing network bridge; use 'none' to disable
   container networking
+
+**--bind-mount-prefix**=""
+  Specify a prefix to use for the source of the bind mounts.
 
 **--bip**=""
   Use the provided CIDR notation address for the dynamically created bridge


### PR DESCRIPTION
Introduce a new config --bind-mount-prefix=PREFIX that adds a prefix
to the source for every bind mount.  This allows Docker to run inside
of a container, and be able to see the host rootfs.

As an example: running Docker with --bind-mount-prefix=/host, will
convert:

docker run -v /var/lib/mariadb:/var/lib/mariadb ...

to:

docker run -v /host/var/lib/mariadb:/var/lib/mariadb ...

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 38e1b7def8b643d109a53a0d4854db6ea91a78df)

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

