### PR TITLE
volume: skip resolving symlinks without a prefix

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -9,8 +9,8 @@ import (
 
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/pkg/symlink"
 	"github.com/opencontainers/runc/libcontainer/label"
 	"github.com/pkg/errors"
 )
@@ -126,15 +126,16 @@ type MountPoint struct {
 // Setup sets up a mount point by either mounting the volume if it is
 // configured, or creating the source directory if supplied.
 func (m *MountPoint) Setup(prefix, mountLabel string, rootUID, rootGID int) (path string, err error) {
-	symlinkRoot := prefix
-	if symlinkRoot == "" {
-		symlinkRoot = "/"
-	}
-	sourcePath, err := symlink.FollowSymlinkInScope(filepath.Join(prefix, m.Source), symlinkRoot)
-	if err != nil {
-		path = ""
-		err = errors.Wrapf(err, "error evaluating symlink from mount source '%s'", m.Source)
-		return
+	var sourcePath string
+	if prefix == "" {
+		sourcePath = m.Source
+	} else {
+		sourcePath, err = symlink.FollowSymlinkInScope(filepath.Join(prefix, m.Source), prefix)
+		if err != nil {
+			path = ""
+			err = errors.Wrapf(err, "error evaluating symlink from mount source '%s'", m.Source)
+			return
+		}
 	}
 
 	defer func() {


### PR DESCRIPTION
drops a part of 38e1b7def8b643d109a53a0d4854db6ea91a78df, so that the
behavior doesn't change when the new feature is not used.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1603201

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit 1235d733a5fbf568bdef7fd0d33348c195483c99)