### PR TITLE
Fix a race in adding references

### DIFF
--- a/reference/store.go
+++ b/reference/store.go
@@ -128,6 +128,11 @@ func (store *store) addReference(ref Named, id digest.Digest, force bool) error 
 	oldID, exists := repository[refStr]
 
 	if exists {
+		if oldID == id {
+			// Nothing to do. The caller may have checked for this using store.Get in advance, but store.mu was unlocked in the meantime, so this can legitimately happen nevertheless.
+			return nil
+		}
+
 		// force only works for tags
 		if digested, isDigest := ref.(Canonical); isDigest {
 			return fmt.Errorf("Cannot overwrite digest %s", digested.Digest().String())

--- a/reference/store_test.go
+++ b/reference/store_test.go
@@ -160,6 +160,10 @@ func TestAddDeleteGet(t *testing.T) {
 	if err = store.AddTag(ref4, testImageID2, false); err != nil {
 		t.Fatalf("error adding to store: %v", err)
 	}
+	// Write the same values again; should silently succeed
+	if err = store.AddTag(ref4, testImageID2, false); err != nil {
+		t.Fatalf("error redundantly adding to store: %v", err)
+	}
 
 	ref5, err := ParseNamed("username/repo3@sha256:58153dfb11794fad694460162bf0cb0a4fa710cfa3f60979c177d920813e267c")
 	if err != nil {
@@ -167,6 +171,10 @@ func TestAddDeleteGet(t *testing.T) {
 	}
 	if err = store.AddDigest(ref5.(Canonical), testImageID2, false); err != nil {
 		t.Fatalf("error adding to store: %v", err)
+	}
+	// Write the same values again; should silently succeed
+	if err = store.AddDigest(ref5.(Canonical), testImageID2, false); err != nil {
+		t.Fatalf("error redundantly adding to store: %v", err)
 	}
 
 	// Attempt to overwrite with force == false


### PR DESCRIPTION
**- What I did**
Fixed a race when two coroutines independently try to add the same digest reference.

**- How I did it**
See the commit message.

**- How to verify it**
On a trivial level, using the modified unit tests. Beyond that, whatever is the usual standard, I guess.

It should be in principle possible to make an actual reproducer by concurrently issuing many pull and/or push API requests for the same image (same manifest digest); I haven’t even attempted that so far. The race window is a few lines of Go code in an operation which involves remote HTTP requests, so it might require quite a few concurrent attempts.

**- Description for the changelog**
Fixes a race possibly causing one of several concurrent push/pull operations with the same remote image fail with “`Cannot overwrite digest …`”.