### PR TITLE
Add tag as SYSLOG_IDENTIFIER for journald log driver

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -60,6 +60,7 @@ func New(ctx logger.Context) (logger.Logger, error) {
 		"CONTAINER_ID_FULL": ctx.ContainerID,
 		"CONTAINER_NAME":    name,
 		"CONTAINER_TAG":     tag,
+		"SYSLOG_IDENTIFIER": tag,
 	}
 	extraAttrs := ctx.ExtraAttributes(strings.ToTitle)
 	for k, v := range extraAttrs {


### PR DESCRIPTION
**- What I did**
Added SYSLOG_IDENTIFIER when using docker journald log driver. When sending logs from journal to rsyslog programname will be set to the SYSLOG_IDENTIFIER and not defaulted to getting set to journal. 

**- How I did it**
https://github.com/moby/moby/commit/ae557f9d85f41e009229d1a33844f06f7ad1fb99
https://docs.docker.com/config/containers/logging/journald/

**- How to verify it**
Run: 
```
# docker run --name logging-test --entrypoint=/bin/echo registry.access.redhat.com/rhel7 "Hello Logs"
# journalctl CONTAINER_NAME=logging-test -o verbose
```
Then look for SYSLOG_IDENTIFIER being set to the same value as CONTAINER_TAG


**- Description for the changelog**
Added tag as SYSLOG_IDENTIFIER for journald log driver