### PR TITLE
Add /proc/keys to masked paths

### DIFF
--- a/oci/defaults_linux.go
+++ b/oci/defaults_linux.go
@@ -80,6 +80,7 @@ func DefaultSpec() specs.Spec {
 		MaskedPaths: []string{
 			"/proc/acpi",
 			"/proc/kcore",
+			"/proc/keys",
 			"/proc/latency_stats",
 			"/proc/timer_list",
 			"/proc/timer_stats",


### PR DESCRIPTION
Cherry pick https://github.com/moby/moby/pull/36368, adding `/proc/keys` to the list of masked paths in `oci/defaults_linux.go`.