### PR TITLE
Don't create source directory while the daemon is being shutdown

### DIFF
--- a/cmd/dockerd/daemon.go
+++ b/cmd/dockerd/daemon.go
@@ -229,6 +229,8 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 	api := apiserver.New(serverConfig)
 	cli.api = api
 
+	var hosts []string
+
 	for i := 0; i < len(cli.Config.Hosts); i++ {
 		var err error
 		if cli.Config.Hosts[i], err = dopts.ParseHost(cli.Config.TLS, cli.Config.Hosts[i]); err != nil {
@@ -260,6 +262,7 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 			}
 		}
 		logrus.Debugf("Listener created for HTTP on %s (%s)", proto, addr)
+		hosts = append(hosts, protoAddrParts[1])
 		api.Accept(addr, ls...)
 	}
 
@@ -284,6 +287,8 @@ func (cli *DaemonCli) start(opts daemonOptions) (err error) {
 	if err != nil {
 		return fmt.Errorf("Error starting daemon: %v", err)
 	}
+
+	d.StoreHosts(hosts)
 
 	if cli.Config.MetricsAddress != "" {
 		if !d.HasExperimental() {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -109,6 +109,18 @@ type Daemon struct {
 
 	seccompProfile     []byte
 	seccompProfilePath string
+
+	hosts map[string]bool // hosts stores the addresses the daemon is listening on
+}
+
+// StoreHosts stores the addresses the daemon is listening on
+func (daemon *Daemon) StoreHosts(hosts []string) {
+	if daemon.hosts == nil {
+		daemon.hosts = make(map[string]bool)
+	}
+	for _, h := range hosts {
+		daemon.hosts[h] = true
+	}
 }
 
 // HasExperimental returns whether the experimental features of the daemon are enabled or not

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -35,7 +35,8 @@ func (daemon *Daemon) StateChanged(id string, e libcontainerd.StateInfo) error {
 		c.StreamConfig.Wait()
 		c.Reset(false)
 
-		restart, wait, err := c.RestartManager().ShouldRestart(e.ExitCode, false, time.Since(c.StartedAt))
+		// If daemon is being shutdown, don't let the container restart
+		restart, wait, err := c.RestartManager().ShouldRestart(e.ExitCode, daemon.IsShuttingDown() || c.HasBeenManuallyStopped, time.Since(c.StartedAt))
 		if err == nil && restart {
 			c.RestartCount++
 			c.SetRestarting(platformConstructExitStatus(e))

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -6,6 +6,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -42,8 +43,19 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, m); err != nil {
 			return nil, err
 		}
+		// If the daemon is being shutdown, we should not let a container start if it is trying to
+		// mount the socket the daemon is listening on. During daemon shutdown, the socket
+		// (/var/run/docker.sock by default) doesn't exist anymore causing the call to m.Setup to
+		// create at directory instead. This in turn will prevent the daemon to restart.
+		checkfunc := func(m *volume.MountPoint) error {
+			if _, exist := daemon.hosts[m.Source]; exist && daemon.IsShuttingDown() {
+				return fmt.Errorf("Could not mount %q to container while the daemon is shutting down", m.Source)
+			}
+			return nil
+		}
+
 		rootUID, rootGID := daemon.GetRemappedUIDGID()
-		path, err := m.Setup(c.MountLabel, rootUID, rootGID)
+		path, err := m.Setup(c.MountLabel, rootUID, rootGID, checkfunc)
 		if err != nil {
 			return nil, err
 		}

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) setupMounts(c *container.Container) ([]container.Mount, er
 		if err := daemon.lazyInitializeVolume(c.ID, mount); err != nil {
 			return nil, err
 		}
-		s, err := mount.Setup(c.MountLabel, 0, 0)
+		s, err := mount.Setup(c.MountLabel, 0, 0, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -124,7 +124,9 @@ type MountPoint struct {
 
 // Setup sets up a mount point by either mounting the volume if it is
 // configured, or creating the source directory if supplied.
-func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string, err error) {
+// The, optional, checkFun parameter allows doing additional checking
+// before creating the source directory on the host.
+func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int, checkFun func(m *MountPoint) error) (path string, err error) {
 	defer func() {
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
@@ -164,6 +166,14 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int) (path string
 	}
 	// system.MkdirAll() produces an error if m.Source exists and is a file (not a directory),
 	if m.Type == mounttypes.TypeBind {
+		// Before creating the source directory on the host, invoke checkFun if it's not nil. One of
+		// the use case is to forbid creating the daemon socket as a directory if the daemon is in
+		// the process of shutting down.
+		if checkFun != nil {
+			if err := checkFun(m); err != nil {
+				return "", err
+			}
+		}
 		// idtools.MkdirAllNewAs() produces an error if m.Source exists and is a file (not a directory)
 		// also, makes sure that if the directory is created, the correct remapped rootUID/rootGID will own it
 		if err := idtools.MkdirAllNewAs(m.Source, 0755, rootUID, rootGID); err != nil {


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**

Ported the patch from https://github.com/moby/moby/pull/33330 into this branch.  The problem is the /var/run/docker.sock file can with the right conditions and bad timing be created as a directory rather than a link when the daemon is shutting down.  Without this change docker would not restart after this timing issue hit until the /var/run/docker.sock directory was removed.

Once this is approved, I will do the same in 1.13.1-RHEL

**- How I did it**

vi is my friend.

**- How to verify it**
The easiest way unfortunately calls for a code change.  Please reference the test methodology in https://github.com/moby/moby/pull/33330.   The file daemon/oci_linux.go needs to be modified and then docker needs to be compiled and installed after the modification.  

**- Description for the changelog**
Don't create /var/run/docker.sock as a directory when the daemon is shutting down

** - Testing:

```
[root@localhost run]# systemctl start docker
[root@localhost run]# docker run -ti --restart always -v /var/run/docker.sock:/sock alpine
/ # exit
[root@localhost run]# systemctl stop docker
[root@localhost run]# systemctl start docker
[root@localhost run]# docker run -ti --restart always -v /var/run/docker.sock:/sock alpine
/ # exit
[root@localhost run]# systemctl stop docker
[root@localhost run]# systemctl start docker
[root@localhost run]# ls -alF docker.sock
srw-rw----. 1 root root 0 Oct 10 19:47 docker.sock=
```
From journalctl with the new log entry showing that the error condition is being handled correctly:
```
Oct 10 19:46:46 localhost.localdomain dockerd-current[4884]: time="2018-10-10T19:46:46.514665986-04:00" level=error msg="restartmanger wait error: Could not mount \"/var/run/docker.sock\" to container while the daemon is shutting down."
```
