### PR TITLE
Remove path from counter when count becomes <= 0

### DIFF
--- a/daemon/graphdriver/counter.go
+++ b/daemon/graphdriver/counter.go
@@ -62,6 +62,10 @@ func (c *RefCounter) Decrement(path string) int {
 		}
 	}
 	m.count--
+	count := m.count
+	if count <= 0 {
+		delete(c.counts, path)
+	}
 	c.mu.Unlock()
 	return m.count
 }


### PR DESCRIPTION
Upstream already behaves this way and it isn't merely an aesthetic
change. Doing this fixes an issue where count can become -1 when a new
daemon instance attempts to unmount the container base dir, with the
later not being actually mounted. The most common action leading to this
scenario is an unorderly restart of the server running docker.

After count becomes -1, a combination of "docker start" + "docker
restart" will lead to a situation in which the mountpoint is not visible
from the global namespace, and attempts to run new processes in the
container will fail with an error like this one:

error: code = 2 desc = oci runtime error: exec failed:
container_linux.go:247: starting container process caused
"process_linux.go:75: starting setns process caused \"fork/exec
/proc/self/exe: no such file or directory\""

Signed-off-by: Sergio Lopez <slp@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

