### PR TITLE
BACKPORT: Fix cpu spin waiting for log write events

### DIFF
--- a/daemon/logger/jsonfilelog/read.go
+++ b/daemon/logger/jsonfilelog/read.go
@@ -271,9 +271,12 @@ func followLogs(f *os.File, logWatcher *logger.LogWatcher, notifyRotate chan int
 
 	handleDecodeErr := func(err error) error {
 		if err == io.EOF {
-			for err := waitRead(); err != nil; {
+			for {
+				err := waitRead()
+				if err == nil {
+					break
+				}
 				if err == errRetry {
-					// retry the waitRead
 					continue
 				}
 				return err


### PR DESCRIPTION
Upstream reference:
https://github.com/moby/moby/commit/7a179972ff963706404f91671960b144dec98d65
Fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1655504

Signed-off-by: Sergio Lopez <slp@redhat.com>