### PR TITLE
Increase default max pid limit

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -93,7 +93,7 @@ func (config *Config) InstallFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&config.InitPath, "init-path", "", "Path to the docker-init binary")
 	flags.Int64Var(&config.CPURealtimePeriod, "cpu-rt-period", 0, "Limit the CPU real-time period in microseconds")
 	flags.Int64Var(&config.CPURealtimeRuntime, "cpu-rt-runtime", 0, "Limit the CPU real-time runtime in microseconds")
-	flags.Int64Var(&config.PidsLimit, "default-pids-limit", 4096, "Limit the number of processes each container is restricted to")
+	flags.Int64Var(&config.PidsLimit, "default-pids-limit", 32768, "Limit the number of processes each container is restricted to")
 	flags.StringVar(&config.SeccompProfile, "seccomp-profile", "", "Path to seccomp profile")
 	flags.BoolVar(&config.SigCheck, "signature-verification", true, "Check image's signatures on pull")
 	flags.BoolVar(&config.EnableSecrets, "enable-secrets", true, "Enable Secrets")


### PR DESCRIPTION
Users were surprised by the suddenly low pid limit on their pods. Change the default to something higher, such as the theoretical maximum number of pids on a 32 bit system.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1696752

Signed-off-by: Peter Hunt <pehunt@redhat.com>