### PR TITLE
Ignore relabeling ENOSUP failure

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	containertypes "github.com/docker/docker/api/types/container"
@@ -51,7 +52,7 @@ func (daemon *Daemon) createContainerPlatformSpecificSettings(container *contain
 			return err
 		}
 
-		if err := label.Relabel(v.Path(), container.MountLabel, true); err != nil {
+		if err := label.Relabel(v.Path(), container.MountLabel, true); err != nil && err != syscall.ENOTSUP {
 			return err
 		}
 


### PR DESCRIPTION
Some file systems like NFS do not support labeling.  We should ignore these failures
and continue on. SELinux policy might need to be adjusted to allow access, but the
relabeling can not be fixed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

