### PR TITLE
Fix stderr logging for journald and syslog

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -84,8 +84,12 @@ func validateLogOpt(cfg map[string]string) error {
 }
 
 func (s *journald) Log(msg *logger.Message) error {
-	if msg.Source == "stderr" {
-		return journal.Send(string(msg.Line), journal.PriErr, s.vars)
+	line := string(msg.Line)
+	source := msg.Source
+	logger.PutMessage(msg)
+
+	if source == "stderr" {
+		return journal.Send(line, journal.PriErr, vars)
 	}
 	return journal.Send(string(msg.Line), journal.PriInfo, s.vars)
 }

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -134,8 +134,11 @@ func New(ctx logger.Context) (logger.Logger, error) {
 }
 
 func (s *syslogger) Log(msg *logger.Message) error {
-	if msg.Source == "stderr" {
-		return s.writer.Err(string(msg.Line))
+	line := string(msg.Line)
+	source := msg.Source
+	logger.PutMessage(msg)
+	if source == "stderr" {
+		return s.writer.Err(line)
 	}
 	return s.writer.Info(string(msg.Line))
 }


### PR DESCRIPTION
logger.PutMessage, added in #28762 (v17.04.0-ce), clears msg.Source. So journald
and syslog were treating stderr messages as if they were stdout.

Signed-off-by: David Glasser <glasser@davidglasser.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
**- What I did**
Backported https://github.com/moby/moby/pull/33832 to projectatomic/docker

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fixes Red Hat [bz1720363](https://bugzilla.redhat.com/show_bug.cgi?id=1720363).
