### PR TITLE
Fix stderr logging for journald and syslog

### DIFF
--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -108,9 +108,10 @@ func (s *journald) Log(msg *logger.Message) error {
 	}
 
 	line := string(msg.Line)
+	source := msg.Source
 	logger.PutMessage(msg)
 
-	if msg.Source == "stderr" {
+	if source == "stderr" {
 		return journal.Send(line, journal.PriErr, vars)
 	}
 	return journal.Send(line, journal.PriInfo, vars)

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -133,8 +133,9 @@ func New(info logger.Info) (logger.Logger, error) {
 
 func (s *syslogger) Log(msg *logger.Message) error {
 	line := string(msg.Line)
+	source := msg.Source
 	logger.PutMessage(msg)
-	if msg.Source == "stderr" {
+	if source == "stderr" {
 		return s.writer.Err(line)
 	}
 	return s.writer.Info(line)


### PR DESCRIPTION
logger.PutMessage, added in #28762 (v17.04.0-ce), clears msg.Source. So journald
and syslog were treating stderr messages as if they were stdout.

Signed-off-by: David Glasser <glasser@davidglasser.net>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
- What I did
Cherry-picked https://github.com/moby/moby/pull/28762 to projectatomic/docker via branch docker-1.13.1-rhel

- Description for the changelog
fixes Red Hat [bz1720363](https://bugzilla.redhat.com/show_bug.cgi?id=1720363).