### PR TITLE
Fix docker cp error per BZ1723491

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -152,7 +152,7 @@ func (daemon *Daemon) containerArchivePath(container *container.Container, path 
 	// container ID.
 	opts := archive.TarResourceRebaseOpts(resolvedPath, filepath.Base(absPath))
 
-	data, err := chrootarchive.Tar(resolvedPath, opts, filepath.Base(absPath))
+	data, err := chrootarchive.Tar(resolvedPath, opts, filepath.Dir(absPath))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**
In the containerArchivePath, change the call at line 155
from `filepath.Base(absPath)` which if our target was `/a` returned 
only 'a', to `filepath.Dir(absPath)` which instead returns '/'.  The 
name of the file is added during the copy operation.

Many thanks to @nalind for the investigative lead.

Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1723491

**- How I did it**
vi is my friend.

**- How to verify it**
Did a number 'docker cp' commands to verify happiness.

**- Description for the changelog**
Fixes docker cp failure


**- A picture of a cute animal (not mandatory but encouraged)**

