### PR TITLE
Fix docker cp issues BZ1723491 & BZ1717087

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -174,6 +174,11 @@ func (daemon *Daemon) containerArchivePath(container *container.Container, path 
 		resolvedCtrDir = filepath.Join(container.BaseFS, resolvedCtrDir)
 	}
 
+	// Make sure we didn't leak outside of container.
+	if !strings.HasPrefix(resolvedCtrDir, container.BaseFS ) {
+		return nil, nil, fmt.Errorf("error targeted directory is not within the container %s", resolvedCtrDir)
+	}
+
 	data, err := chrootarchive.Tar(resolvedPath, opts, resolvedCtrDir)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**
There are two BZs https://bugzilla.redhat.com/show_bug.cgi?id=1723491 and https://bugzilla.redhat.com/show_bug.cgi?id=1717087 reporting an issue using `docker cp` to a container.  Upon testing, further issues were discovered if the target in the container was a symlink.  This code finds the target directory on the host's local container storage (/var/lib/docker/overlay2), resolves any symlinks and ensures the file gets copied to/from the container without any potential cve leakage.

**- How I did it**
VI and lots of blood, sweat and tears for this one.

**- How to verify it**
```
# docker run -t -i --name testctr --rm fedora bash

//Inside the container:
# ln -s /tmp /test

//Outside the container:
# touch testfile; docker cp testfile testctr:/test

//In the container,
# ls /tmp

// Outside the container,
# ls /tmp

//The file "testfile" should be shown in the ls within the container, but NOT with the ls outside the container.

# docker cp testctr:/test/testfile.txt  /tmp/newtestfile.txt
// /tmp on the host should have the file newtestfile.txt
```

**- Description for the changelog**
Addresses docker cp issue noted in BZ1717087 and BZ1723491

**- A picture of a cute animal (not mandatory but encouraged)**

