### PR TITLE
Address CVE-2019-13509 - secret leakage in debug logging

### DIFF
--- a/api/server/middleware/debug.go
+++ b/api/server/middleware/debug.go
@@ -61,10 +61,24 @@ func maskSecretKeys(inp interface{}) {
 		}
 		return
 	}
+
 	if form, ok := inp.(map[string]interface{}); ok {
+		scrub := []string{
+			// Note: The Data field contains the base64-encoded secret in 'secret'
+			// and 'config' create and update requests. Currently, no other POST
+			// API endpoints use a data field, so we scrub this field unconditionally.
+			// Change this handling to be conditional if a new endpoint is added
+			// in future where this field should not be scrubbed.
+			"data",
+			"jointoken",
+			"password",
+			"secret",
+			"signingcakey",
+			"unlockkey",
+		}
 	loop0:
 		for k, v := range form {
-			for _, m := range []string{"password", "secret", "jointoken", "unlockkey"} {
+			for _, m := range scrub {
 				if strings.EqualFold(m, k) {
 					form[k] = "*****"
 					continue loop0

--- a/api/server/middleware/debug_test.go
+++ b/api/server/middleware/debug_test.go
@@ -1,0 +1,75 @@
+package middleware // import "github.com/docker/docker/api/server/middleware"
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+)
+
+func TestMaskSecretKeys(t *testing.T) {
+	tests := []struct {
+		doc      string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			doc:      "secret/config create and update requests",
+			input:    map[string]interface{}{"Data": "foo", "Name": "name", "Labels": map[string]interface{}{}},
+			expected: map[string]interface{}{"Data": "*****", "Name": "name", "Labels": map[string]interface{}{}},
+		},
+		{
+			doc: "masking other fields (recursively)",
+			input: map[string]interface{}{
+				"password":     "pass",
+				"secret":       "secret",
+				"jointoken":    "jointoken",
+				"unlockkey":    "unlockkey",
+				"signingcakey": "signingcakey",
+				"other": map[string]interface{}{
+					"password":     "pass",
+					"secret":       "secret",
+					"jointoken":    "jointoken",
+					"unlockkey":    "unlockkey",
+					"signingcakey": "signingcakey",
+				},
+			},
+			expected: map[string]interface{}{
+				"password":     "*****",
+				"secret":       "*****",
+				"jointoken":    "*****",
+				"unlockkey":    "*****",
+				"signingcakey": "*****",
+				"other": map[string]interface{}{
+					"password":     "*****",
+					"secret":       "*****",
+					"jointoken":    "*****",
+					"unlockkey":    "*****",
+					"signingcakey": "*****",
+				},
+			},
+		},
+		{
+			doc: "case insensitive field matching",
+			input: map[string]interface{}{
+				"PASSWORD": "pass",
+				"other": map[string]interface{}{
+					"PASSWORD": "pass",
+				},
+			},
+			expected: map[string]interface{}{
+				"PASSWORD": "*****",
+				"other": map[string]interface{}{
+					"PASSWORD": "*****",
+				},
+			},
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.doc, func(t *testing.T) {
+			maskSecretKeys(testcase.input)
+			assert.Check(t, is.DeepEqual(testcase.expected, testcase.input))
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

**- What I did**
Applied patch that was put into upstream to address CVE-2019-13509 .   (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13509).  Patch on upstream located at: https://github.com/dweomer/docker/pull/82

This is the patch for docker-1.13.1-rhel, the first was for docker-1.13.1 at #355 

**- How I did it**
vi and some blood, sweat and tears.

**- How to verify it**
```
Prior behavior (from: https://github.com/dweomer/docker/pull/82/commits/73db8c77bfb2d0cbdf71ce491f3d3e66c9dd5be6)

1. Start the daemon in debug-mode

        dockerd --debug

        or have the following entry in /etc/docker/daemon.json
 
        "debug": true

       Also ensure that live-restore is NOT enabled/configured on the system.

2. Initialize swarm

        docker swarm init

3. Create a file containing a secret

        echo secret > my_secret.txt

4. Create a docker-compose file using that secret

        cat > docker-compose.yml <<'EOF'
        version: "3.1"
        services:
          web:
            image: nginx:alpine
            secrets:
              - my_secret
        secrets:
          my_secret:
            file: ./my_secret.txt
        EOF

5. Deploy the stack

        docker stack deploy -c docker-compose.yml test

6. Verify that the secret is scrubbed in the daemon logs

        DEBU[2019-07-01T22:36:08.170617400Z] Calling POST /v1.30/secrets/create
        DEBU[2019-07-01T22:36:08.171364900Z] form data: {"Data":"*****","Labels":{"com.docker.stack.namespace":"test"},"Name":"test_my_secret"}

7. Re-deploy the stack to trigger an "update"

        docker stack deploy -c docker-compose.yml test

8. Notice that this time, the Data field is not scrubbed, and the base64-encoded secret is logged

        DEBU[2019-07-01T22:37:35.828819400Z] Calling POST /v1.30/secrets/w3hgvwpzl8yooq5ctnyp71v52/update?version=34
        DEBU[2019-07-01T22:37:35.829993700Z] form data: {"Data":"c2VjcmV0Cg==","Labels":{"com.docker.stack.namespace":"test"},"Name":"test_my_secret"}

9. With this fix in t place, the DATA field here will also contain asterisks "*****".
```

This patch introduces some change in behavior:

- In addition to secrets, requests to create or update _configs_ will
  now have their `Data` field scrubbed. Generally, the actual data should
  not be interesting for debugging, so likely will not be problematic.
  In addition, scrubbing this data for configs may actually be desirable,
  because (even though they are not explicitely designed for this purpose)
  configs may contain sensitive data (credentials inside a configuration
  file, e.g.).
- Requests that send key/value pairs as a "map" and that contain a
  key named "data", will see the value of that field scrubbed. This
  means that (e.g.) setting a `label` named `data` on a config, will
  scrub/mask the value of that label.
- Note that this is already the case for any label named `jointoken`,
  `password`, `secret`, `signingcakey`, or `unlockkey`.


**- Description for the changelog**
Addresses CVE-2019-13509 - secret leakage in debug logging

**- A picture of a cute animal (not mandatory but encouraged)**

