### PR TITLE
Fix for bad copy BZ1741718 1.13.1

### DIFF
--- a/daemon/archive.go
+++ b/daemon/archive.go
@@ -272,7 +272,7 @@ func (daemon *Daemon) containerExtractToDir(container *container.Container, path
 		}
 	}
 
-	if err := chrootarchive.UntarWithRoot(content, absPath, options, container.BaseFS); err != nil {
+	if err := chrootarchive.UntarWithRoot(content, resolvedPath, options, container.BaseFS); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Change the variable passed to the UntarWithRoot() function in the extraction code path from the absPath variable to the resolvedPath variable.  If copying the file testfile to /var/lib/testfile, absPath would contain the value `/var/lib` while the resolvedPath contains a value like: 

```
/var/lib/docker/overlay2/d4d26da4cdca9dc168143c1e3dfca8684780721ee80ece01f77f5716b390a5d1/merged/var/lib
```
Where the containers root is the value less the ending `/var/lib`.

In the extraction routine the call to "filepath.Rel(ctrRoot, '/var/lib')" would fail as it returned `/../../../../` (4 up directories) rather than `/../../../../../../` (6 up directories) as it should have been.  Passing in the fully specified target directory from the hosts perspective, rather than the directory from inside the container's perspective fixes this issue.

This tracks with what upstream Docker does.

Addresses: https://bugzilla.redhat.com/show_bug.cgi?id=1741718

This has the same content as the docker 1.13.1-rhel branch PR at:  https://github.com/projectatomic/docker/pull/357

**- How I did it**
Lot's of testing, debugging and a bit of vi.

**- How to verify it**
```
# dd if=/dev/zero of=/tmp/testfile bs=1M count=1
# docker run --rm --name test -dt rhel7 bash
# docker cp /tmp/testfile test:/var/lib/mytestfile
# docker exec -ti test ls -l /var/lib/mytestfile /mytestfile 
ls: cannot access /mytestfile: No such file or directory
-rw-r--r--. 1 root root 1048576 Aug 23 19:00 /var/lib/mytestfile

Secondary test (To validate a regression did not occur with this change)
# docker exec -ti test ln -s /tmp /test
# docker cp /tmp/testfile test:/test/mytestfile
# docker exec -ti test ls -l /test/mytestfile /tmp/mytestfile
-rw-r--r--. 1 root root 1048576 Aug 23 19:00 /test/mytestfile
-rw-r--r--. 1 root root 1048576 Aug 23 19:00 /tmp/mytestfile

# find / -name mytestfile
# only shows files under /var/lib/docker/overlay/{id}/{merged | diff}/   
# and no where else on the host.

```
**- Description for the changelog**

Corrects a file copy to a container issue when a file with `/var` or `/lib` was part of the target.


**- A picture of a cute animal (not mandatory but encouraged)**
