### PR TITLE
Fixes CVE-2019-13139 git ref cmd injection

### DIFF
--- a/pkg/gitutils/gitutils.go
+++ b/pkg/gitutils/gitutils.go
@@ -65,6 +65,10 @@ func cloneArgs(remoteURL *url.URL, root string) []string {
 func checkoutGit(fragment, root string) (string, error) {
 	refAndDir := strings.SplitN(fragment, ":", 2)
 
+	if strings.HasPrefix(refAndDir[0], "-") {
+		return "", fmt.Errorf("invalid refspec: %s", refAndDir[0])
+	}
+
 	if len(refAndDir[0]) != 0 {
 		if output, err := gitWithinDir(root, "checkout", refAndDir[0]); err != nil {
 			return "", fmt.Errorf("Error trying to use git: %s (%s)", err, output)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add a check to the git reference to validate that it did not have a leading dash '-' in front of it, allowing for a security injection.  This is per CVE-2019-13139 and BZ https://bugzilla.redhat.com/show_bug.cgi?id=1733941

Corresponding change from upstream Docker: https://github.com/moby/moby/pull/38944

**- How I did it**
Lots of vi and testing.

**- How to verify it**
Without the fix this is the way to reproduce the issue:
```
# rm -rf /tmp/docker-build-git* 
# docker build 'git://github.com/RedHatOfficial/openhardware#-btest-branch:test'  # ignore any errors
# cd /tmp/docker-build-git* 
# git branch 
```
With the error in play there will be a master and a rogue test branch created, the test branch should not be there.

With the fix:
```
# rm -rf /tmp/docker-build-git* 
# docker build 'git://github.com/RedHatOfficial/openhardware#-btest-branch:test'  # ignore any errors
unable to prepare context: unable to 'git clone' to temporary context directory: invalid refspec: -btest-branch
# cd /tmp/docker-build-git* 
# git branch 
```
and only the master branch should be there.

**- Description for the changelog**

Addresses CVE-2019-13139 -  docker: command injection due to a missing validation of the git ref command

**- A picture of a cute animal (not mandatory but encouraged)**

