### PR TITLE
fix potential dead locks using `WaitStop`

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -793,7 +793,6 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 			if err := daemon.kill(c, int(sig)); err != nil {
 				logrus.Errorf("Failed to SIGKILL container %s", c.ID)
 			}
-			c.WaitStop(-1 * time.Second)
 			return err
 		}
 	}
@@ -802,7 +801,6 @@ func (daemon *Daemon) shutdownContainer(c *container.Container) error {
 		return fmt.Errorf("Failed to stop container %s with error: %v", c.ID, err)
 	}
 
-	c.WaitStop(-1 * time.Second)
 	return nil
 }
 

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -144,7 +144,6 @@ func (daemon *Daemon) Kill(container *container.Container) error {
 		return err
 	}
 
-	container.WaitStop(-1 * time.Second)
 	return nil
 }
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -73,7 +73,6 @@ func (daemon *Daemon) containerStop(container *container.Container, seconds int)
 		logrus.Infof("Container %v failed to exit within %d seconds of signal %d - using the force", container.ID, seconds, stopSignal)
 		// 3. If it doesn't, then send SIGKILL
 		if err := daemon.Kill(container); err != nil {
-			container.WaitStop(-1 * time.Second)
 			logrus.Warn(err) // Don't return error because we only care that container is stopped, not what function stopped it
 		}
 	}


### PR DESCRIPTION
Using `container.WaitStop` with a negative time out can lead to dead
locks when the container's `waitChan` it's not being closed or written
to.  The `waitChan` is closed only in seemingly unrelated code paths.

However, we only run into the `WaitStop` when the container was still
running during the second (redundant) kill; a rare case, which according to
my theory causes the dead lock.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1751422
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @giuseppe @TomSweeneyRedHat PTAL