### PR TITLE
WIP - allow storing images with >= 127 layers

### DIFF
--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -455,9 +455,6 @@ func (d *Driver) getLower(parent string) (string, error) {
 		parentLowers := strings.Split(string(parentLower), ":")
 		lowers = append(lowers, parentLowers...)
 	}
-	if len(lowers) > maxDepth {
-		return "", errors.New("max depth exceeded")
-	}
 	return strings.Join(lowers, ":"), nil
 }
 
@@ -529,6 +526,10 @@ func (d *Driver) Get(id string, mountLabel string) (s string, err error) {
 
 	workDir := path.Join(dir, "work")
 	splitLowers := strings.Split(string(lowers), ":")
+	if len(splitLowers) >= maxDepth {
+		return "", errors.New("max depth exceeded")
+	}
+
 	absLowers := make([]string, len(splitLowers))
 	for i, s := range splitLowers {
 		absLowers[i] = path.Join(d.home, s)

--- a/layer/layer_store.go
+++ b/layer/layer_store.go
@@ -263,10 +263,6 @@ func (ls *layerStore) registerWithDescriptor(ts io.Reader, parent ChainID, descr
 				ls.layerL.Unlock()
 			}
 		}()
-		if p.depth() >= maxLayerDepth {
-			err = ErrMaxDepthExceeded
-			return nil, err
-		}
 	}
 
 	// Create new roLayer


### PR DESCRIPTION
There is an overlay2 restriction that limits the maximum number of
(lower) layers to 127 which is induced by kernel's maximum arguments and
possible the size as well when mounting.  The checks are very strict in
that we cannot even store images exceeding this limit.  However, some
images might not be meant to be running in a container.  Hence, defer
checking the number of (lower) layers right before mounting trying to
mount a layer in overlay2.  Also remove the #layer checks when storing
images.  Now, we can store but not mount these images.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@rhatdan @vbatts PTAL