### PR TITLE
[1.13.1] CVE 20201702

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -2,13 +2,13 @@ package registry
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/iolimits"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/docker/distribution/registry/client/transport"
@@ -51,7 +51,7 @@ func loginV1(authConfig *types.AuthConfig, apiEndpoint APIEndpoint, userAgent st
 		}
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := iolimits.ReadAtMost(resp.Body, iolimits.MaxErrorBodySize)
 	if err != nil {
 		return "", "", err
 	}

--- a/registry/endpoint_v1.go
+++ b/registry/endpoint_v1.go
@@ -4,12 +4,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/iolimits"
 	"github.com/docker/distribution/registry/client/transport"
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
@@ -164,7 +164,7 @@ func (e *V1Endpoint) Ping() (PingResult, error) {
 
 	defer resp.Body.Close()
 
-	jsonString, err := ioutil.ReadAll(resp.Body)
+	jsonString, err := iolimits.ReadAtMost(resp.Body, 1 << 20) // 1 MiB is sufficiently enough
 	if err != nil {
 		return PingResult{Standalone: false}, fmt.Errorf("error while reading the http response: %s", err)
 	}

--- a/vendor/github.com/containers/image/docker/docker_client.go
+++ b/vendor/github.com/containers/image/docker/docker_client.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/image/docker/reference"
+	"github.com/containers/image/iolimits"
 	"github.com/containers/image/types"
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/docker/distribution/registry/client"
@@ -349,7 +350,7 @@ func (c *dockerClient) getBearerToken(realm, service, scope string) (*bearerToke
 	default:
 		return nil, errors.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, authReq.URL)
 	}
-	tokenBlob, err := ioutil.ReadAll(res.Body)
+	tokenBlob, err := iolimits.ReadAtMost(res.Body, iolimits.MaxAuthTokenBodySize)
 	if err != nil {
 		return nil, err
 	}
@@ -492,7 +493,7 @@ func (c *dockerClient) getExtensionsSignatures(ref dockerReference, manifestDige
 	if res.StatusCode != http.StatusOK {
 		return nil, client.HandleErrorResponse(res)
 	}
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxSignatureListBodySize)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/containers/image/docker/docker_image_dest.go
+++ b/vendor/github.com/containers/image/docker/docker_image_dest.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/iolimits"
 	"github.com/containers/image/docker/reference"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
@@ -233,7 +234,7 @@ func (d *dockerImageDestination) PutManifest(m []byte) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusCreated {
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxErrorBodySize)
 		if err == nil {
 			logrus.Debugf("Error body %s", string(body))
 		}
@@ -417,7 +418,7 @@ sigExists:
 		}
 		defer res.Body.Close()
 		if res.StatusCode != http.StatusCreated {
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := iolimits.ReadAtMost(res.Body, iolimits.MaxErrorBodySize)
 			if err == nil {
 				logrus.Debugf("Error body %s", string(body))
 			}

--- a/vendor/github.com/containers/image/image/docker_schema2.go
+++ b/vendor/github.com/containers/image/image/docker_schema2.go
@@ -5,10 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/containers/image/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -112,7 +112,7 @@ func (m *manifestSchema2) ConfigBlob() ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/image/image/oci.go
+++ b/vendor/github.com/containers/image/image/oci.go
@@ -2,8 +2,8 @@ package image
 
 import (
 	"encoding/json"
-	"io/ioutil"
 
+	"github.com/containers/image/iolimits"
 	"github.com/containers/image/manifest"
 	"github.com/containers/image/types"
 	"github.com/opencontainers/go-digest"
@@ -68,7 +68,7 @@ func (m *manifestOCI1) ConfigBlob() ([]byte, error) {
 			return nil, err
 		}
 		defer stream.Close()
-		blob, err := ioutil.ReadAll(stream)
+		blob, err := iolimits.ReadAtMost(stream, iolimits.MaxConfigBodySize)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/containers/image/iolimits/iolimits.go
+++ b/vendor/github.com/containers/image/iolimits/iolimits.go
@@ -1,0 +1,60 @@
+package iolimits
+
+import (
+	"io"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+// All constants below are intended to be used as limits for `ReadAtMost`. The
+// immediate use-case for limiting the size of in-memory copied data is to
+// protect against OOM DOS attacks as described inCVE-2020-1702. Instead of
+// copying data until running out of memory, we error out after hitting the
+// specified limit.
+const (
+	// megaByte denotes one megabyte and is intended to be used as a limit in
+	// `ReadAtMost`.
+	megaByte = 1 << 20
+	// MaxManifestBodySize is the maximum allowed size of a manifest. The limit
+	// of 4 MB aligns with the one of a Docker registry:
+	// https://github.com/docker/distribution/blob/a8371794149d1d95f1e846744b05c87f2f825e5a/registry/handlers/manifests.go#L30
+	MaxManifestBodySize = 4 * megaByte
+	// MaxAuthTokenBodySize is the maximum allowed size of an auth token.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxAuthTokenBodySize = megaByte
+	// MaxSignatureListBodySize is the maximum allowed size of a signature list.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureListBodySize = 4 * megaByte
+	// MaxSignatureBodySize is the maximum allowed size of a signature.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxSignatureBodySize = 4 * megaByte
+	// MaxErrorBodySize is the maximum allowed size of an error-response body.
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxErrorBodySize = megaByte
+	// MaxConfigBodySize is the maximum allowed size of a config blob.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxConfigBodySize = 4 * megaByte
+	// MaxOpenShiftStatusBody is the maximum allowed size of an OpenShift status body.
+	// The limit of 4 MB is considered to be greatly sufficient.
+	MaxOpenShiftStatusBody = 4 * megaByte
+	// MaxTarFileManifestSize is the maximum allowed size of a (docker save)-like manifest (which may contain multiple images)
+	// The limit of 1 MB is considered to be greatly sufficient.
+	MaxTarFileManifestSize = megaByte
+)
+
+// ReadAtMost reads from reader and errors out if the specified limit (in bytes) is exceeded.
+func ReadAtMost(reader io.Reader, limit int) ([]byte, error) {
+	limitedReader := io.LimitReader(reader, int64(limit+1))
+
+	res, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res) > limit {
+		return nil, errors.Errorf("exceeded maximum allowed size of %d bytes", limit)
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/containers/image/iolimits/iolimits.go
+++ b/vendor/github.com/containers/image/iolimits/iolimits.go
@@ -41,6 +41,13 @@ const (
 	// MaxTarFileManifestSize is the maximum allowed size of a (docker save)-like manifest (which may contain multiple images)
 	// The limit of 1 MB is considered to be greatly sufficient.
 	MaxTarFileManifestSize = megaByte
+
+	// SPECIAL TYPES FOR DOCKER
+
+	MaxDistributionDescriptorSize = 4 * megaByte
+
+	MaxAllTagsSize = megaByte
+
 )
 
 // ReadAtMost reads from reader and errors out if the specified limit (in bytes) is exceeded.

--- a/vendor/github.com/containers/image/iolimits/iolimits_test.go
+++ b/vendor/github.com/containers/image/iolimits/iolimits_test.go
@@ -1,0 +1,36 @@
+package iolimits
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadAtMost(t *testing.T) {
+	for _, c := range []struct {
+		input, limit  int
+		shouldSucceed bool
+	}{
+		{0, 0, true},
+		{0, 1, true},
+		{1, 0, false},
+		{1, 1, true},
+		{bytes.MinRead*5 - 1, bytes.MinRead * 5, true},
+		{bytes.MinRead * 5, bytes.MinRead * 5, true},
+		{bytes.MinRead*5 + 1, bytes.MinRead * 5, false},
+	} {
+		input := make([]byte, c.input)
+		_, err := rand.Read(input)
+		require.NoError(t, err)
+		result, err := ReadAtMost(bytes.NewReader(input), c.limit)
+		if c.shouldSucceed {
+			assert.NoError(t, err)
+			assert.Equal(t, result, input)
+		} else {
+			assert.Error(t, err)
+		}
+	}
+}

--- a/vendor/github.com/docker/distribution/registry/client/errors.go
+++ b/vendor/github.com/docker/distribution/registry/client/errors.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
+	"github.com/containers/image/iolimits"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/client/auth/challenge"
 )
@@ -40,7 +40,7 @@ func (e *UnexpectedHTTPResponseError) Error() string {
 
 func parseHTTPErrorResponse(statusCode int, r io.Reader) error {
 	var errors errcode.Errors
-	body, err := ioutil.ReadAll(r)
+	body, err := iolimits.ReadAtMost(r, iolimits.MaxErrorBodySize)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR includes two commits to fix https://bugzilla.redhat.com/show_bug.cgi?id=1792796:

* Backport the upstream fixes to the _vendored_ version of containers/image. I would have preferred to vendor in a branch of c/image containing the fixes but that was not possible as the vendored code has already been downstream patched. It's not as clean as I want it to be, but here we are :^) Note that the `iolimits` package is not internal to c/image.
* Use the `iolimits` package in docker and the vendored distribution code.

@rhatdan @TomSweeneyRedHat PTAL