### PR TITLE
Release SELinux labels on error in init function.

### DIFF
--- a/vendor/github.com/opencontainers/runc/libcontainer/label/label_selinux.go
+++ b/vendor/github.com/opencontainers/runc/libcontainer/label/label_selinux.go
@@ -24,17 +24,22 @@ var ErrIncompatibleLabel = fmt.Errorf("Bad SELinux option z and Z can not be use
 // the container.  A list of options can be passed into this function to alter
 // the labels.  The labels returned will include a random MCS String, that is
 // guaranteed to be unique.
-func InitLabels(options []string) (string, string, error) {
+func InitLabels(options []string) (plabel string, mlabel string, Err error) {
 	if !selinux.SelinuxEnabled() {
 		return "", "", nil
 	}
 	processLabel, mountLabel := selinux.GetLxcContexts()
 	if processLabel != "" {
+		defer func() {
+			if Err != nil {
+				ReleaseLabel(mountLabel)
+			}
+		}()
 		pcon := selinux.NewContext(processLabel)
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
 			if opt == "disable" {
-				return "", "", nil
+				return "", mountLabel, nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)


### PR DESCRIPTION
This is a backport of an upstream fix for:

https://github.com/opencontainers/selinux/commit/fd7b61c28f9e134d36a5911eb1550f2704e4bf8e

Currently if we have an error in the options, we will leak and allocated
SELinux label.  This change will release on error.

Also return the mountlabel, even if the user specifies to disable SELinux separation.  This keeps other containers from being able to look at this privileged
containers content, as well makeing sure all content has a label.

This should fix an issue we see where we leak labels in the docker daemon, causing over time large usage memory.