### PR TITLE
Fix bindmount autocreate race

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -14,7 +14,7 @@ import (
 	mounttypes "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/container"
 	"github.com/docker/docker/volume"
-	"github.com/docker/docker/volume/drivers"
+	volumedrivers "github.com/docker/docker/volume/drivers"
 )
 
 var (
@@ -192,6 +192,10 @@ func (daemon *Daemon) registerMountPoints(container *container.Container, hostCo
 			}); ok {
 				mp.Source = cv.CachedPath()
 			}
+		}
+
+		if mp.Type == mounttypes.TypeBind {
+			mp.SkipMountpointCreation = true
 		}
 
 		binds[mp.Destination] = true


### PR DESCRIPTION
When using the mounts API, bind mounts are not supposed to be
automatically created.

Before this patch there is a race condition between validating that a
bind path exists and then actually setting up the bind mount where the
bind path may exist during validation but was removed during mountpooint
setup.

This adds a field to the mountpoint struct to ensure that binds created
over the mounts API are not accidentally created.

@kolyshkin: port of upstream commit 1caeb79963d3c9f770b23be2f/PR https://github.com/moby/moby/pull/37378 

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>

