### PR TITLE
Docker 1.13.1 rhel reconnect

### DIFF
--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -63,6 +63,26 @@ type remote struct {
 	restoreFromTimestamp  *timestamp.Timestamp
 }
 
+func (r *remote) newConn() error {
+	// don't output the grpc reconnect logging
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+
+	dialOpts := append([]grpc.DialOption{grpc.WithInsecure()},
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		}),
+	)
+	conn, err := grpc.Dial(r.rpcAddr, dialOpts...)
+	if err != nil {
+		return fmt.Errorf("error connecting to containerd: %v", err)
+	}
+
+	r.rpcConn = conn
+	r.apiClient = containerd.NewAPIClient(conn)
+
+	return nil
+}
+
 // New creates a fresh instance of libcontainerd remote.
 func New(stateDir string, options ...RemoteOption) (_ Remote, err error) {
 	defer func() {
@@ -95,20 +115,9 @@ func New(stateDir string, options ...RemoteOption) (_ Remote, err error) {
 		}
 	}
 
-	// don't output the grpc reconnect logging
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-	dialOpts := append([]grpc.DialOption{grpc.WithInsecure()},
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
-		}),
-	)
-	conn, err := grpc.Dial(r.rpcAddr, dialOpts...)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to containerd: %v", err)
+	if err := r.newConn(); err != nil {
+		return nil, err
 	}
-
-	r.rpcConn = conn
-	r.apiClient = containerd.NewAPIClient(conn)
 
 	// Get the timestamp to restore from
 	t := r.getLastEventTimestamp()

--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -166,7 +166,7 @@ func (r *remote) handleConnectionChange() {
 		logrus.Debugf("libcontainerd: containerd health check returned error: %v", err)
 
 		if r.daemonPid != -1 {
-			if strings.Contains(err.Error(), "is closing") {
+			if r.closeManually {
 				// Well, we asked for it to stop, just return
 				return
 			}

--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -141,12 +141,10 @@ func (r *remote) handleConnectionChange() {
 
 	logrus.Debugf("libcontainerd: maximum number of retries for containerd health check is %d", r.maxHealthCheckRetries)
 
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
 	healthClient := grpc_health_v1.NewHealthClient(r.rpcConn)
 
 	for {
-		<-ticker.C
+		time.Sleep(500 * time.Millisecond)
 		ctx, cancel := context.WithTimeout(context.Background(), containerdHealthCheckTimeout)
 		_, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 		cancel()

--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -67,11 +67,13 @@ func (r *remote) newConn() error {
 	// don't output the grpc reconnect logging
 	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
 
-	dialOpts := append([]grpc.DialOption{grpc.WithInsecure()},
+	dialOpts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithBackoffMaxDelay(2 * time.Second),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}),
-	)
+	}
 	conn, err := grpc.Dial(r.rpcAddr, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("error connecting to containerd: %v", err)

--- a/libcontainerd/remote_unix.go
+++ b/libcontainerd/remote_unix.go
@@ -49,7 +49,7 @@ type remote struct {
 	stateDir              string
 	rpcAddr               string
 	startDaemon           bool
-	closeManually         bool
+	closedManually        bool
 	debugLog              bool
 	rpcConn               *grpc.ClientConn
 	clients               []*client
@@ -166,7 +166,7 @@ func (r *remote) handleConnectionChange() {
 		logrus.Debugf("libcontainerd: containerd health check returned error: %v", err)
 
 		if r.daemonPid != -1 {
-			if r.closeManually {
+			if r.closedManually {
 				// Well, we asked for it to stop, just return
 				return
 			}
@@ -208,7 +208,7 @@ func (r *remote) Cleanup() {
 	if r.daemonPid == -1 {
 		return
 	}
-	r.closeManually = true
+	r.closedManually = true
 	r.rpcConn.Close()
 	// Ask the daemon to quit
 	syscall.Kill(r.daemonPid, syscall.SIGTERM)
@@ -308,10 +308,23 @@ func (r *remote) startEventsMonitor() error {
 	er := &containerd.EventsRequest{
 		Timestamp: tsp,
 	}
-	events, err := r.apiClient.Events(context.Background(), er, grpc.FailFast(false))
-	if err != nil {
-		return err
+
+	var events containerd.API_EventsClient
+	for {
+		events, err = r.apiClient.Events(context.Background(), er, grpc.FailFast(false))
+		if err == nil {
+			break
+		}
+		logrus.Warnf("libcontainerd: failed to get events from containerd: %q", err)
+
+		if r.closedManually {
+			// ignore error if grpc remote connection is closed manually
+			return nil
+		}
+
+		<-time.After(100 * time.Millisecond)
 	}
+
 	go r.handleEventStream(events)
 	return nil
 }
@@ -321,7 +334,7 @@ func (r *remote) handleEventStream(events containerd.API_EventsClient) {
 		e, err := events.Recv()
 		if err != nil {
 			if grpc.ErrorDesc(err) == transport.ErrConnClosing.Desc &&
-				r.closeManually {
+				r.closedManually {
 				// ignore error if grpc remote connection is closed manually
 				return
 			}


### PR DESCRIPTION
### 1. libct/handleConnectionChange: reconnect to containerd
    
In case we are killing and restarting containerd, do try to reconnect
and use the new connection.
    
Loosely based on PR https://github.com/moby/moby/pull/36173
    
Might help https://bugzilla.redhat.com/show_bug.cgi?id=1746435
    
### 2. libcontainerd/handleConnectionChange: use sleep
    
Quoting the upstream commit:
    
> With the ticker this could end up just doing back-to-back checks,
> which isn't really what we want here.  Instead use a sleep to
> ensure we actually sleep for the desired interval.
    
Similar upstream commit: 04a0d6b863ed50cfffa79 (PR https://github.com/moby/moby/pull/36577)

### 3. fix when rpc reports "transport is closing" error, health check go routine will exit

This is a backport of commit 60742f9a95cb5eff549a8 (PR https://github.com/moby/moby/pull/32986)

### 4. Fix when containerd restarted, event handler may exit

This is a backport of commit 02ce73f62e73e78a4ec29b29 (PR https://github.com/moby/moby/pull/32590).

Fixing a real issue that emerged after testing the above fixes (1 and 2).

### 5. Limit max backoff delay to 2 seconds for GRPC connection

This is a backport of commit d3d8c77d195ce74f36ae6eee  (PR https://github.com/moby/moby/pull/33493)