### PR TITLE
Free SELinux labels when the labels are not being used

### DIFF
--- a/vendor/src/github.com/opencontainers/runc/libcontainer/label/label_selinux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/label/label_selinux.go
@@ -34,13 +34,16 @@ func InitLabels(options []string) (string, string, error) {
 		mcon := selinux.NewContext(mountLabel)
 		for _, opt := range options {
 			if opt == "disable" {
+				UnreserveLabel(processLabel)
 				return "", "", nil
 			}
 			if i := strings.Index(opt, ":"); i == -1 {
+				UnreserveLabel(processLabel)
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable' or \n'user, role, level, type' followed by ':' and a value", opt)
 			}
 			con := strings.SplitN(opt, ":", 2)
 			if !validOptions[con[0]] {
+				UnreserveLabel(processLabel)
 				return "", "", fmt.Errorf("Bad label option %q, valid options 'disable, user, role, level, type'", con[0])
 
 			}


### PR DESCRIPTION
Currently when lots of containers are created as disabled, each
container will leak and MCS Label.  Eventually the system will run out
of labels and go into an infinate loop looking for labels.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/docker/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

