### PR TITLE
Fix masking/ignoring relabeling error

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -140,7 +140,8 @@ func (m *MountPoint) Setup(mountLabel string, rootUID, rootGID int, checkFun fun
 	defer func() {
 		if err == nil {
 			if label.RelabelNeeded(m.Mode) {
-				sourcePath, err := filepath.EvalSymlinks(m.Source)
+				var sourcePath string
+				sourcePath, err = filepath.EvalSymlinks(m.Source)
 				if err != nil {
 					path = ""
 					err = errors.Wrapf(err, "error evaluating symlink from mount source '%s'", m.Source)


### PR DESCRIPTION
Commit 317e94be44d64cf0 introduced a local variable err, which masked
the err used as a named return value. As a result, any relabeling error
(happened in that defer) is not returned, and the caller gets `"", nil`,
moving on to performing a bind mount with empty m.Source argument
(which, apparently, results in mounting a current directory).

This can be reproduced by trying to add a bind mount which has no space
left (see RHBZ link below for details).

This issue was spotted upstream during the review, and fixed before the
merge (see https://github.com/moby/moby/pull/34792#issuecomment-330355030).
In this repository, though, it was never fixed.

Fixes: https://bugzilla.redhat.com/1878621