### PR TITLE
Fix authz zero length regression

### DIFF
--- a/pkg/authorization/authz.go
+++ b/pkg/authorization/authz.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -51,10 +53,23 @@ type Ctx struct {
 	authReq *Request
 }
 
+func isChunked(r *http.Request) bool {
+	// RFC 7230 specifies that content length is to be ignored if Transfer-Encoding is chunked
+	if strings.EqualFold(r.Header.Get("Transfer-Encoding"), "chunked") {
+		return true
+	}
+	for _, v := range r.TransferEncoding {
+		if strings.EqualFold(v, "chunked") {
+			return true
+		}
+	}
+	return false
+}
+
 // AuthZRequest authorized the request to the docker daemon using authZ plugins
 func (ctx *Ctx) AuthZRequest(w http.ResponseWriter, r *http.Request) error {
 	var body []byte
-	if sendBody(ctx.requestURI, r.Header) && r.ContentLength > 0 && r.ContentLength < maxBodySize {
+	if sendBody(ctx.requestURI, r.Header) && (r.ContentLength > 0 || isChunked(r)) && r.ContentLength < maxBodySize {
 		var err error
 		body, r.Body, err = drainBody(r.Body)
 		if err != nil {
@@ -107,7 +122,6 @@ func (ctx *Ctx) AuthZResponse(rm ResponseModifier, r *http.Request) error {
 	if sendBody(ctx.requestURI, rm.Header()) {
 		ctx.authReq.ResponseBody = rm.RawBody()
 	}
-
 	for _, plugin := range ctx.plugins {
 		logrus.Debugf("AuthZ response using plugin %s", plugin.Name())
 
@@ -145,10 +159,26 @@ func drainBody(body io.ReadCloser) ([]byte, io.ReadCloser, error) {
 	return nil, newBody, err
 }
 
+func isAuthEndpoint(urlPath string) (bool, error) {
+	// eg www.test.com/v1.24/auth/optional?optional1=something&optional2=something (version optional)
+	matched, err := regexp.MatchString(`^[^\/]*\/(v\d[\d\.]*\/)?auth.*`, urlPath)
+	if err != nil {
+		return false, err
+	}
+	return matched, nil
+}
+
 // sendBody returns true when request/response body should be sent to AuthZPlugin
-func sendBody(url string, header http.Header) bool {
+func sendBody(inURL string, header http.Header) bool {
+	u, err := url.Parse(inURL)
+	// Assume no if the URL cannot be parsed - an empty request will still be forwarded to the plugin and should be rejected
+	if err != nil {
+		return false
+	}
+
 	// Skip body for auth endpoint
-	if strings.HasSuffix(url, "/auth") {
+	isAuth, err := isAuthEndpoint(u.Path)
+	if isAuth || err != nil {
 		return false
 	}
 

--- a/pkg/authorization/authz_unix_test.go
+++ b/pkg/authorization/authz_unix_test.go
@@ -172,6 +172,144 @@ func TestDrainBody(t *testing.T) {
 	}
 }
 
+func TestSendBody(t *testing.T) {
+	var (
+		testcases = []struct {
+			url         string
+			contentType string
+			expected    bool
+		}{
+			{
+				contentType: "application/json",
+				expected:    true,
+			},
+			{
+				contentType: "Application/json",
+				expected:    true,
+			},
+			{
+				contentType: "application/JSON",
+				expected:    true,
+			},
+			{
+				contentType: "APPLICATION/JSON",
+				expected:    true,
+			},
+			{
+				contentType: "application/json; charset=utf-8",
+				expected:    true,
+			},
+			{
+				contentType: "application/json;charset=utf-8",
+				expected:    true,
+			},
+			{
+				contentType: "application/json; charset=UTF8",
+				expected:    true,
+			},
+			{
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				contentType: "text/html",
+				expected:    false,
+			},
+			{
+				contentType: "",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/auth",
+				contentType: "",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/auth?p1=test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/test?p1=/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				url:         "nothing.com/something/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				url:         "nothing.com/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/v1.24/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "nothing.com/v1/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "www.nothing.com/v1.24/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "https://www.nothing.com/v1.24/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "http://nothing.com/v1.24/auth/test",
+				contentType: "application/json;charset=UTF8",
+				expected:    false,
+			},
+			{
+				url:         "www.nothing.com/test?p1=/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				url:         "http://www.nothing.com/test?p1=/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				url:         "www.nothing.com/something/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+			{
+				url:         "https://www.nothing.com/something/auth",
+				contentType: "application/json;charset=UTF8",
+				expected:    true,
+			},
+		}
+	)
+
+	for _, testcase := range testcases {
+		header := http.Header{}
+		header.Set("Content-Type", testcase.contentType)
+		if testcase.url == "" {
+			testcase.url = "nothing.com"
+		}
+
+		if b := sendBody(testcase.url, header); b != testcase.expected {
+			t.Fatalf("sendBody failed: url: %s, content-type: %s; Expected: %t, Actual: %t", testcase.url, testcase.contentType, testcase.expected, b)
+		}
+	}
+}
+ 
 func TestResponseModifierOverride(t *testing.T) {
 	r := httptest.NewRecorder()
 	m := NewResponseModifier(r)


### PR DESCRIPTION
Fixes CVE-2024-41110.

The fix was originally taken from moby 19.03 and applied to RHEL 7.9. I've been advised to "upstream" it here as well.
